### PR TITLE
Add gwt worktree helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,12 @@ Key files:
 - **`Brewfile`** — source of truth for all Homebrew formulae/casks
 - **`packages/mise/.config/mise/config.toml`** — tool version pins (e.g., Node) and mise task definitions
 - **`packages/npm/global-packages.txt`** — global npm CLIs installed by `install.sh`
+- **`packages/bin/.local/bin/`** — user-facing CLI helpers, including agent/task utilities such as `gwt`
 - **`scripts/lib/ui.sh`** — shared shell UI helpers (`step`, `ok`, `warn`, `skip`, etc.) sourced by all scripts
 - **`scripts/checks/`** — individual check scripts invoked by `check-updates.sh`
+
+Ignore handling:
+- This repo installs and may rely on a global Git ignore file configured via `core.excludesFile` for machine-local/generated paths, so an empty repo-local `.gitignore` does not necessarily mean those paths are intended to be tracked
 
 ## Shell Script Conventions
 
@@ -29,6 +33,8 @@ Key files:
 - 4-space indentation; explicit conditionals
 - Source `scripts/lib/ui.sh` for all user-facing output; never use raw `echo` for status messages
 - Kebab-case filenames in `scripts/`; package folder names match the tool name in lowercase
+- Treat `scripts/` as repository maintenance/install/check code, not as a general AI-agent utility area
+- Add new user-facing or agent-facing CLIs under `packages/bin/.local/bin/` unless they are strictly maintenance helpers for this repo
 
 ## Commit Style
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -61,8 +61,7 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 | `prefix + H/J/K/L` | Resize pane | `packages/tmux/.tmux.conf` |
 | `prefix + t` | New window (keep cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + n/p` | Next/previous window | `packages/tmux/.tmux.conf` |
-| `prefix + L` | Apply saved layout | `packages/tmux/.tmux.conf` |
-| `prefix + P` | Sync all pane cwd to current pane | `packages/tmux/.tmux.conf` |
+| `prefix + s` | Open session chooser (`choose-tree`) | `packages/tmux/.tmux.conf` |
 | `copy-mode` + `v` | Begin selection | `packages/tmux/.tmux.conf` |
 | `copy-mode` + `y` | Copy selection to macOS clipboard | `packages/tmux/.tmux.conf` |
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,21 @@ Custom location: set `DOTFILES_DIR` before running tasks, e.g.
   - Homebrew (`brew update --quiet` + `brew outdated`)
   - mise tools (`mise outdated`)
   - sheldon plugins (pinned `rev` vs latest tags)
+- AI agent worktrees:
+  - Requires `tmux`; after `./install.sh`, use `gwt` from `~/.local/bin/gwt`
+  - Requires the selected agent CLI on `PATH` (`codex`, `claude`, or `copilot`); `gwt new` and `gwt open` validate it before opening the task window
+  - New project sessions start with window `1` named `@root` for repo-level shell work, overview, and non-worktree commands
+  - `task` names are restricted to letters, numbers, `.`, `_`, and `-` (for example `tmux-status`); names like `feat/tmux-status` are rejected
+  - `gwt new <task> --agent <codex|claude|copilot>` creates a new `.worktrees/<task>` plus a tmux window in the project session
+  - `gwt open <task>` reopens an existing task window for a task recorded in `gwt` metadata and works across tmux sessions
+  - `gwt open --force <task>` bypasses stale branch-metadata checks after warning; use it only for recovery when the recorded branch no longer matches the registered worktree branch
+  - `gwt ls` shows `task / agent / status / dirty / worktree / stale`
+  - `stale=yes` means the recorded metadata no longer matches reality (for example the worktree is missing or no longer registered on the recorded branch)
+  - `gwt rm <task>` closes the window and removes the worktree for a `gwt`-managed task; it refuses dirty worktrees, and local branches are left alone
+  - `gwt rm --force <task>` also discards uncommitted changes in that worktree; use it only for recovery
+  - `gwt` treats `.worktrees/.gwt/tasks/*.tsv` as the source of truth for managed tasks; if that metadata is missing, the task no longer appears in `gwt ls` and must be inspected or cleaned up with raw `git worktree` commands
+  - Useful recovery commands for orphaned worktrees: `git worktree list`, `git worktree remove .worktrees/<task>`, and `git branch -d <branch>` when you also want to drop the branch
+  - tmux window names are refreshed automatically as `task [agent:●|◌|·]` for busy, idle, and inactive states
 - If `brew bundle` or `mise install` fails mid-run, fix the cause then rerun `mise run dotfiles:install`.
   - If you don't use mise tasks, run `./scripts/check-updates.sh`
 
@@ -82,6 +97,7 @@ This repository uses a package-based organization:
 ```
 packages/
 ├── aerospace/  # AeroSpace window manager configuration
+├── bin/        # User-facing CLI helpers installed into ~/.local/bin
 ├── claude/     # Claude Code settings and configurations
 ├── git/        # Git configuration
 ├── karabiner/  # Karabiner-Elements configuration
@@ -103,6 +119,8 @@ Each package contains dotfiles in their expected directory structure. The instal
 - **packages/mise/.config/mise/config.toml** - tool pins and mise tasks (`dotfiles:install`, `dotfiles:check-updates`)
 - **Brewfile** - Homebrew package definitions
 - **install.sh** - Main installation script with custom symlinking logic
-- **scripts/** - helper scripts (e.g. `check-updates.sh`, `lib/ui.sh`)
+- **scripts/** - repository maintenance scripts (install/check/update helpers such as `check-updates.sh`, `lib/ui.sh`)
+- **packages/bin/.local/bin/gwt** - tmux + git worktree launcher for AI-agent tasks
+- **packages/bin/.local/bin/** - user-facing CLI helpers; prefer this location for agent/task utilities instead of `scripts/`
 - **packages/** - Individual application configurations
 - **KEYBINDINGS.md** - cheat sheet for custom macOS/terminal/Neovim keybindings

--- a/packages/bin/.local/bin/gwt
+++ b/packages/bin/.local/bin/gwt
@@ -1,0 +1,805 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+STATUS_IDLE_SECONDS="${GWT_STATUS_IDLE_SECONDS:-2}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  gwt new <task> --agent <codex|claude|copilot> [--branch <branch>] [--base <branch>]
+  gwt open [--force] <task>
+  gwt ls
+  gwt rm [--force] <task>
+
+Notes:
+  - gwt metadata under .worktrees/.gwt/tasks/*.tsv is the source of truth for managed tasks
+  - if metadata is missing, the task will not appear in 'gwt ls'; inspect or clean it up with 'git worktree list' and 'git worktree remove .worktrees/<task>'
+EOF
+}
+
+die() {
+  printf 'gwt: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+require_git_repo() {
+  git rev-parse --path-format=absolute --git-common-dir >/dev/null 2>&1 ||
+    die "not inside a git repository"
+}
+
+script_dir() {
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+}
+
+status_loop_command() {
+  printf '%s/gwt-status-loop\n' "$(script_dir)"
+}
+
+repo_root() {
+  local git_common_dir
+
+  git_common_dir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+  dirname "$git_common_dir"
+}
+
+root_window_label() {
+  printf '%s\n' '@root'
+}
+
+project_name() {
+  local root
+  local base
+  root="$(repo_root)"
+  base="$(basename "$root")"
+  base="$(printf '%s' "$base" | tr -c '[:alnum:]_-' '-')"
+  base="${base##[-_]}"
+  base="${base%%[-_]}"
+  printf '%s\n' "${base:-project}"
+}
+
+session_name_for_repo() {
+  printf '%s-%s\n' "$(project_name)" "$(repo_hash_for_root)"
+}
+
+gwt_dir() {
+  printf '%s/.worktrees/.gwt\n' "$(repo_root)"
+}
+
+metadata_dir() {
+  printf '%s/tasks\n' "$(gwt_dir)"
+}
+
+ensure_metadata_dirs() {
+  mkdir -p "$(metadata_dir)"
+}
+
+repo_hash_for_root() {
+  repo_root | shasum | awk '{print substr($1, 1, 10)}'
+}
+
+task_key_for_name() {
+  printf '%s' "$1" | shasum | awk '{print $1}'
+}
+
+meta_file_for_task() {
+  printf '%s/%s.tsv\n' "$(metadata_dir)" "$(task_key_for_name "$1")"
+}
+
+validate_task_name() {
+  local task="$1"
+
+  [[ -n "$task" ]] || die "task is required"
+  [[ "$task" != -* ]] || die "task must not start with '-'"
+  [[ "$task" != *..* ]] || die "task must not contain '..'"
+  [[ "$task" =~ ^[A-Za-z0-9._-]+$ ]] || die "task may only contain letters, numbers, '.', '_' and '-'"
+}
+
+validate_branch_name() {
+  local branch="$1"
+
+  [[ -n "$branch" ]] || die "branch is required"
+  git check-ref-format --branch "$branch" >/dev/null 2>&1 || die "invalid branch name: $branch"
+}
+
+assert_no_tsv_control_chars() {
+  local value="$1"
+  local field_name="$2"
+
+  [[ "$value" != *$'\t'* ]] || die "$field_name must not contain tabs"
+  [[ "$value" != *$'\n'* ]] || die "$field_name must not contain newlines"
+}
+
+write_task_metadata() {
+  local task="$1"
+  local agent="$2"
+  local worktree="$3"
+  local branch="$4"
+  local root
+  local file
+
+  root="$(repo_root)"
+  file="$(meta_file_for_task "$task")"
+  ensure_metadata_dirs
+
+  assert_no_tsv_control_chars "$task" "task"
+  assert_no_tsv_control_chars "$agent" "agent"
+  assert_no_tsv_control_chars "$worktree" "worktree"
+  assert_no_tsv_control_chars "$branch" "branch"
+  assert_no_tsv_control_chars "$root" "root"
+
+  printf '%s\t%s\t%s\t%s\t%s\n' "$task" "$agent" "$worktree" "$branch" "$root" >"$file"
+}
+
+load_task_metadata() {
+  local requested_task="$1"
+  local file
+
+  file="$(meta_file_for_task "$requested_task")"
+  [[ -f "$file" ]] || return 1
+
+  IFS=$'\t' read -r task agent worktree branch root <"$file" || return 1
+
+  [[ -n "${task:-}" && -n "${agent:-}" && -n "${worktree:-}" && -n "${branch:-}" && -n "${root:-}" ]] ||
+    die "invalid metadata file: $file"
+  [[ "$task" == "$requested_task" ]] || die "metadata task mismatch: $file"
+}
+
+agent_command() {
+  case "$1" in
+    codex)
+      printf '%s\n' "codex"
+      ;;
+    claude)
+      printf '%s\n' "claude"
+      ;;
+    copilot)
+      printf '%s\n' "copilot"
+      ;;
+    *)
+      die "unsupported agent: $1"
+      ;;
+  esac
+}
+
+agent_command_name() {
+  local command
+  command="$(agent_command "$1")"
+  printf '%s\n' "${command%% *}"
+}
+
+pane_has_agent_process() {
+  local pane_id="$1"
+  local agent="$2"
+  local expected_cmd
+  local tty
+  local process_list
+
+  expected_cmd="$(agent_command_name "$agent")"
+  tty="$(tmux display-message -p -t "$pane_id" '#{pane_tty}' 2>/dev/null || true)"
+  [[ -n "$tty" ]] || return 1
+
+  process_list="$(ps -t "$tty" -o command= 2>/dev/null || true)"
+  [[ -n "$process_list" ]] || return 1
+
+  printf '%s\n' "$process_list" | grep -E "(^|[[:space:]/])${expected_cmd}([[:space:]]|$)" >/dev/null 2>&1
+}
+
+window_label() {
+  local task="$1"
+  local agent="$2"
+  local status="$3"
+  local status_symbol
+
+  case "$status" in
+    busy)
+      status_symbol="●"
+      ;;
+    idle)
+      status_symbol="◌"
+      ;;
+    *)
+      status_symbol="·"
+      ;;
+  esac
+
+  printf '%s [%s:%s]\n' "$task" "$agent" "$status_symbol"
+}
+
+find_window_by_task() {
+  local session="$1"
+  local task="$2"
+
+  tmux list-windows -t "$session" -F '#{window_id}	#{@gwt_task}' 2>/dev/null |
+    awk -F '\t' -v task="$task" '$2 == task { print $1; exit }'
+}
+
+is_dirty_worktree() {
+  local worktree="$1"
+  if [[ -n "$(git -C "$worktree" status --porcelain 2>/dev/null)" ]]; then
+    printf 'yes\n'
+  else
+    printf 'no\n'
+  fi
+}
+
+registered_worktree_branch() {
+  local worktree="$1"
+  local root
+
+  root="$(repo_root)"
+  git -C "$root" worktree list --porcelain |
+    awk -v target="$worktree" '
+      $1 == "worktree" {
+        current = substr($0, index($0, " ") + 1)
+        next
+      }
+      $1 == "branch" && current == target {
+        print substr($0, index($0, " ") + 1)
+        found = 1
+        exit
+      }
+      $0 == "" {
+        current = ""
+      }
+      END {
+        if (!found) {
+          exit 1
+        }
+      }
+    '
+}
+
+registered_worktree_for_task() {
+  local task="$1"
+  printf '%s/.worktrees/%s\n' "$(repo_root)" "$task"
+}
+
+ensure_session() {
+  local session="$1"
+  local root="$2"
+
+  if ! tmux has-session -t "$session" 2>/dev/null; then
+    tmux new-session -d -s "$session" -c "$root" -n "$(root_window_label)"
+  fi
+
+  ensure_status_refresher "$session"
+}
+
+ensure_status_refresher() {
+  local session="$1"
+  local command
+
+  if pgrep -f "[/]gwt-status-loop --session ${session}$" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  command="$(status_loop_command)"
+  [[ -x "$command" ]] || die "required command not found: $command"
+  nohup "$command" --session "$session" >/dev/null 2>&1 &
+}
+
+cleanup_session_if_idle() {
+  local session="$1"
+  local task_window_count
+  local window_count
+
+  tmux has-session -t "$session" 2>/dev/null || return 0
+
+  task_window_count="$(tmux list-windows -t "$session" -F '#{@gwt_task}' 2>/dev/null | awk 'NF { count++ } END { print count + 0 }')"
+  [[ "$task_window_count" == "0" ]] || return 0
+
+  window_count="$(tmux list-windows -t "$session" 2>/dev/null | wc -l | tr -d ' ')"
+  [[ "$window_count" == "1" ]] || return 0
+
+  tmux kill-session -t "$session"
+}
+
+prepare_window_layout() {
+  local session="$1"
+  local task="$2"
+  local worktree="$3"
+  local agent="$4"
+  local window_id
+  local top_pane
+  local bottom_pane
+  local command
+  local current_agent=""
+  local agent_running="0"
+
+  window_id="$(find_window_by_task "$session" "$task")"
+  if [[ -n "$window_id" ]]; then
+    top_pane="$(tmux show-options -w -v -t "$window_id" @gwt_agent_pane 2>/dev/null || true)"
+    if [[ -z "$top_pane" ]] || ! tmux list-panes -t "$window_id" -F '#{pane_id}' | grep -Fx "$top_pane" >/dev/null 2>&1; then
+      top_pane="$(tmux list-panes -t "$window_id" -F '#{pane_id}' | head -n1)"
+    fi
+
+    bottom_pane="$(tmux show-options -w -v -t "$window_id" @gwt_shell_pane 2>/dev/null || true)"
+    if [[ -z "$bottom_pane" ]] || ! tmux list-panes -t "$window_id" -F '#{pane_id}' | grep -Fx "$bottom_pane" >/dev/null 2>&1; then
+      bottom_pane="$(tmux split-window -d -v -p 25 -t "$top_pane" -c "$worktree" -P -F '#{pane_id}')"
+      tmux select-layout -t "$window_id" main-horizontal >/dev/null 2>&1 || true
+    fi
+
+    current_agent="$(tmux show-options -w -v -t "$window_id" @gwt_agent 2>/dev/null || true)"
+    command="$(agent_command "$agent")"
+
+    if pane_has_agent_process "$top_pane" "$agent"; then
+      agent_running="1"
+    fi
+
+    tmux set-option -w -t "$window_id" @gwt_task "$task"
+    tmux set-option -w -t "$window_id" @gwt_agent "$agent"
+    tmux set-option -w -t "$window_id" @gwt_worktree "$worktree"
+    tmux set-option -w -t "$window_id" @gwt_root "$(repo_root)"
+    tmux set-option -w -t "$window_id" @gwt_agent_pane "$top_pane"
+    tmux set-option -w -t "$window_id" @gwt_shell_pane "$bottom_pane"
+
+    if [[ "$current_agent" != "$agent" || "$agent_running" != "1" ]]; then
+      tmux respawn-pane -k -t "$top_pane" -c "$worktree" "$command"
+      tmux set-option -w -t "$window_id" @gwt_last_hash ""
+      tmux set-option -w -t "$window_id" @gwt_last_change_epoch "0"
+    fi
+
+    tmux rename-window -t "$window_id" "$(window_label "$task" "$agent" "-")"
+    tmux select-pane -t "$top_pane"
+    printf '%s\n' "$window_id"
+    return 0
+  fi
+
+  window_id="$(tmux new-window -d -P -F '#{window_id}' -t "$session" -n "$task" -c "$worktree")"
+  top_pane="$(tmux list-panes -t "$window_id" -F '#{pane_id}' | head -n1)"
+  bottom_pane="$(tmux split-window -d -v -p 25 -t "$top_pane" -c "$worktree" -P -F '#{pane_id}')"
+  command="$(agent_command "$agent")"
+
+  tmux set-option -w -t "$window_id" @gwt_task "$task"
+  tmux set-option -w -t "$window_id" @gwt_agent "$agent"
+  tmux set-option -w -t "$window_id" @gwt_worktree "$worktree"
+  tmux set-option -w -t "$window_id" @gwt_root "$(repo_root)"
+  tmux set-option -w -t "$window_id" @gwt_agent_pane "$top_pane"
+  tmux set-option -w -t "$window_id" @gwt_shell_pane "$bottom_pane"
+  tmux set-option -w -t "$window_id" @gwt_last_hash ""
+  tmux set-option -w -t "$window_id" @gwt_last_change_epoch "0"
+  tmux rename-window -t "$window_id" "$(window_label "$task" "$agent" "-")"
+  tmux select-layout -t "$window_id" main-horizontal >/dev/null 2>&1 || true
+  tmux send-keys -t "$top_pane" "$command" C-m
+  tmux select-pane -t "$top_pane"
+
+  printf '%s\n' "$window_id"
+}
+
+attach_or_switch() {
+  local session="$1"
+  local window_target="${2:-}"
+
+  if [[ -n "$window_target" ]]; then
+    tmux select-window -t "$window_target"
+  fi
+
+  if [[ -n "${TMUX:-}" ]]; then
+    tmux switch-client -t "$session"
+  else
+    tmux attach-session -t "$session"
+  fi
+}
+
+parse_status() {
+  local window_id="$1"
+  local agent="$2"
+  local pane_id
+  local expected_cmd
+  local current_cmd
+  local snapshot
+  local new_hash
+  local last_hash
+  local now
+  local last_change
+  local age
+
+  pane_id="$(tmux show-options -w -v -t "$window_id" @gwt_agent_pane 2>/dev/null || true)"
+  [[ -n "$pane_id" ]] || {
+    printf '%s\n' "-"
+    return 0
+  }
+
+  expected_cmd="$(agent_command_name "$agent")"
+  current_cmd="$(tmux display-message -p -t "$pane_id" '#{pane_current_command}' 2>/dev/null || true)"
+
+  if [[ "$current_cmd" != "$expected_cmd" ]] && ! pane_has_agent_process "$pane_id" "$agent"; then
+    printf '%s\n' "-"
+    return 0
+  fi
+
+  snapshot="$(tmux capture-pane -p -t "$pane_id" -S -200 2>/dev/null || true)"
+  new_hash="$(printf '%s' "$snapshot" | shasum | awk '{print $1}')"
+  last_hash="$(tmux show-options -w -v -t "$window_id" @gwt_last_hash 2>/dev/null || true)"
+  last_change="$(tmux show-options -w -v -t "$window_id" @gwt_last_change_epoch 2>/dev/null || printf '0')"
+  now="$(date +%s)"
+
+  if [[ "$new_hash" != "$last_hash" ]]; then
+    tmux set-option -w -t "$window_id" @gwt_last_hash "$new_hash" >/dev/null
+    tmux set-option -w -t "$window_id" @gwt_last_change_epoch "$now" >/dev/null
+    printf '%s\n' "busy"
+    return 0
+  fi
+
+  age=$((now - last_change))
+  if (( age <= STATUS_IDLE_SECONDS )); then
+    printf '%s\n' "busy"
+  else
+    printf '%s\n' "idle"
+  fi
+}
+
+refresh_status() {
+  local target_session="${1:-}"
+  local window_id
+  local task
+  local agent
+  local status
+
+  require_cmd tmux
+  require_git_repo
+
+  if [[ -z "$target_session" ]]; then
+    if [[ -n "${TMUX:-}" ]]; then
+      target_session="$(tmux display-message -p '#{session_name}')"
+    else
+      target_session="$(session_name_for_repo)"
+    fi
+  fi
+
+  tmux has-session -t "$target_session" 2>/dev/null || return 0
+
+  while IFS=$'\t' read -r window_id task agent; do
+    [[ -n "$window_id" && -n "$task" && -n "$agent" ]] || continue
+    status="$(parse_status "$window_id" "$agent")"
+    tmux rename-window -t "$window_id" "$(window_label "$task" "$agent" "$status")"
+  done < <(tmux list-windows -t "$target_session" -F '#{window_id}	#{@gwt_task}	#{@gwt_agent}')
+}
+
+cmd_new() {
+  local task="${1:-}"
+  local agent=""
+  local agent_cmd=""
+  local branch=""
+  local base=""
+  local actual_branch=""
+  local session
+  local root
+  local worktree
+  local window_id
+  local metadata_file
+
+  cleanup_new_task() {
+    [[ "${GWT_NEW_SUCCESS:-0}" == "1" ]] && return 0
+
+    if [[ "${GWT_NEW_CREATED_METADATA:-0}" == "1" ]]; then
+      rm -f "${GWT_NEW_METADATA_FILE:-}"
+    fi
+
+    if [[ "${GWT_NEW_CREATED_WORKTREE:-0}" == "1" && -d "${GWT_NEW_WORKTREE:-}" ]]; then
+      git -C "${GWT_NEW_ROOT:-$(repo_root)}" worktree remove --force "${GWT_NEW_WORKTREE:-}" >/dev/null 2>&1 || true
+    fi
+
+    if [[ "${GWT_NEW_CREATED_BRANCH:-0}" == "1" ]]; then
+      git -C "${GWT_NEW_ROOT:-$(repo_root)}" branch -D "${GWT_NEW_BRANCH:-}" >/dev/null 2>&1 || true
+    fi
+  }
+
+  trap cleanup_new_task RETURN
+  GWT_NEW_SUCCESS="0"
+  GWT_NEW_CREATED_BRANCH="0"
+  GWT_NEW_CREATED_WORKTREE="0"
+  GWT_NEW_CREATED_METADATA="0"
+
+  validate_task_name "$task"
+  shift || true
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        [[ $# -ge 2 ]] || die "--agent requires a value"
+        agent="${2:-}"
+        shift 2
+        ;;
+      --branch)
+        [[ $# -ge 2 ]] || die "--branch requires a value"
+        branch="${2:-}"
+        shift 2
+        ;;
+      --base)
+        [[ $# -ge 2 ]] || die "--base requires a value"
+        base="${2:-}"
+        shift 2
+        ;;
+      *)
+        die "unknown option: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$agent" ]] || die "--agent is required"
+  require_cmd git
+  require_cmd tmux
+  require_git_repo
+  agent_cmd="$(agent_command_name "$agent")"
+  require_cmd "$agent_cmd"
+  if [[ -z "$branch" ]]; then
+    branch="$task"
+  fi
+  validate_branch_name "$branch"
+  root="$(repo_root)"
+  session="$(session_name_for_repo)"
+  worktree="${root}/.worktrees/${task}"
+  metadata_file="$(meta_file_for_task "$task")"
+  GWT_NEW_ROOT="$root"
+  GWT_NEW_BRANCH="$branch"
+  GWT_NEW_WORKTREE="$worktree"
+  GWT_NEW_METADATA_FILE="$metadata_file"
+
+  ensure_metadata_dirs
+
+  if [[ -f "$metadata_file" ]]; then
+    die "task '$task' already has metadata; remove it with 'gwt rm $task' or clean up $(gwt_dir)"
+  fi
+
+  if [[ -d "$worktree" ]]; then
+    actual_branch="$(registered_worktree_branch "$worktree" 2>/dev/null || true)"
+    if [[ -n "$actual_branch" ]]; then
+      actual_branch="${actual_branch#refs/heads/}"
+      die "task '$task' already exists on branch '$actual_branch' but is not tracked in gwt metadata; restore metadata in $(metadata_dir) or manage the worktree with git directly"
+    fi
+    die "path exists but is not a registered git worktree: $worktree"
+  fi
+
+  if [[ -z "$base" ]]; then
+    base="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || printf 'HEAD')"
+  fi
+
+  if git -C "$root" show-ref --verify --quiet "refs/heads/${branch}"; then
+    git -C "$root" worktree add "$worktree" "$branch"
+  else
+    git -C "$root" worktree add -b "$branch" "$worktree" "$base"
+    GWT_NEW_CREATED_BRANCH="1"
+  fi
+  GWT_NEW_CREATED_WORKTREE="1"
+
+  write_task_metadata "$task" "$agent" "$worktree" "$branch"
+  GWT_NEW_CREATED_METADATA="1"
+
+  ensure_session "$session" "$root"
+  window_id="$(prepare_window_layout "$session" "$task" "$worktree" "$agent")"
+  refresh_status "$session"
+  attach_or_switch "$session" "$window_id"
+  GWT_NEW_SUCCESS="1"
+}
+
+cmd_open() {
+  local task=""
+  local force="0"
+  local session
+  local window_id
+  local agent_cmd=""
+  local actual_branch=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)
+        force="1"
+        shift
+        ;;
+      *)
+        if [[ -z "$task" ]]; then
+          task="$1"
+          shift
+        else
+          die "unknown option: $1"
+        fi
+        ;;
+    esac
+  done
+
+  validate_task_name "$task"
+
+  [[ $# -eq 0 ]] || die "unknown option: $1"
+
+  require_cmd git
+  require_cmd tmux
+  require_git_repo
+
+  load_task_metadata "$task" || die "unknown gwt-managed task: $task (metadata not found in $(metadata_dir))"
+  [[ -d "$worktree" ]] || die "worktree missing: $worktree"
+  actual_branch="$(registered_worktree_branch "$worktree" 2>/dev/null || true)"
+  [[ -n "$actual_branch" ]] || die "worktree is not registered with git: $worktree"
+  actual_branch="${actual_branch#refs/heads/}"
+  if [[ "$actual_branch" != "$branch" ]]; then
+    if [[ "$force" != "1" ]]; then
+      die "task '$task' metadata is stale: metadata branch=$branch, worktree branch=$actual_branch (use 'gwt open --force $task' to continue)"
+    fi
+    printf 'gwt: warning: task %s metadata is stale: metadata branch=%s, worktree branch=%s; continuing because --force was provided\n' \
+      "$task" "$branch" "$actual_branch" >&2
+  fi
+  agent_cmd="$(agent_command_name "$agent")"
+  require_cmd "$agent_cmd"
+  session="$(session_name_for_repo)"
+  ensure_session "$session" "$(repo_root)"
+  window_id="$(prepare_window_layout "$session" "$task" "$worktree" "$agent")"
+
+  refresh_status "$session"
+  attach_or_switch "$session" "$window_id"
+}
+
+cmd_ls() {
+  local session
+  local metadata
+  local task_name
+  local agent_name
+  local worktree_path
+  local branch_name
+  local worktree_state
+  local window_id
+  local status
+  local dirty
+  local stale
+  local actual_branch
+
+  require_cmd git
+  require_cmd tmux
+  require_git_repo
+  ensure_metadata_dirs
+  session="$(session_name_for_repo)"
+
+  printf '%-20s %-8s %-6s %-5s %-8s %-5s\n' "TASK" "AGENT" "STATUS" "DIRTY" "WORKTREE" "STALE"
+
+  shopt -s nullglob
+  for metadata in "$(metadata_dir)"/*.tsv; do
+    IFS=$'\t' read -r task agent worktree branch root <"$metadata" || continue
+    [[ -n "${task:-}" && -n "${agent:-}" && -n "${worktree:-}" && -n "${branch:-}" && -n "${root:-}" ]] || continue
+    task_name="$task"
+    agent_name="$agent"
+    worktree_path="$worktree"
+    branch_name="$branch"
+    window_id=""
+    status="-"
+    stale="no"
+
+    if [[ -d "$worktree_path" ]]; then
+      worktree_state="present"
+      dirty="$(is_dirty_worktree "$worktree_path")"
+      actual_branch="$(registered_worktree_branch "$worktree_path" 2>/dev/null || true)"
+
+      if tmux has-session -t "$session" 2>/dev/null; then
+        window_id="$(find_window_by_task "$session" "$task_name")"
+        if [[ -n "$window_id" ]]; then
+          status="$(parse_status "$window_id" "$agent_name")"
+        fi
+      fi
+
+      if [[ -z "$actual_branch" ]]; then
+        stale="yes"
+      else
+        actual_branch="${actual_branch#refs/heads/}"
+        if [[ "$actual_branch" != "$branch_name" ]]; then
+          stale="yes"
+        fi
+      fi
+    else
+      worktree_state="missing"
+      dirty="-"
+      stale="yes"
+    fi
+
+    printf '%-20s %-8s %-6s %-5s %-8s %-5s\n' "$task_name" "$agent_name" "$status" "$dirty" "$worktree_state" "$stale"
+  done
+}
+
+cmd_rm() {
+  local task=""
+  local force="0"
+  local session
+  local window_id
+  local metadata_file=""
+  local dirty="no"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)
+        force="1"
+        shift
+        ;;
+      *)
+        if [[ -z "$task" ]]; then
+          task="$1"
+          shift
+        else
+          die "unknown option: $1"
+        fi
+        ;;
+    esac
+  done
+
+  validate_task_name "$task"
+  require_cmd git
+  require_git_repo
+  load_task_metadata "$task" || die "unknown gwt-managed task: $task (metadata not found in $(metadata_dir))"
+  metadata_file="$(meta_file_for_task "$task")"
+
+  if [[ -d "$worktree" ]]; then
+    dirty="$(is_dirty_worktree "$worktree")"
+    if [[ "$dirty" == "yes" && "$force" != "1" ]]; then
+      die "worktree has uncommitted changes: $worktree (use 'gwt rm --force $task' to discard them)"
+    fi
+  fi
+
+  session="$(session_name_for_repo)"
+
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session" 2>/dev/null; then
+    window_id="$(find_window_by_task "$session" "$task")"
+    if [[ -n "$window_id" ]]; then
+      tmux kill-window -t "$window_id"
+    fi
+  fi
+
+  if [[ -d "$worktree" ]]; then
+    if [[ "$force" == "1" ]]; then
+      git -C "$(repo_root)" worktree remove --force "$worktree"
+    else
+      git -C "$(repo_root)" worktree remove "$worktree"
+    fi
+  fi
+
+  rm -f "$metadata_file"
+  cleanup_session_if_idle "$session"
+}
+
+main() {
+  local command="${1:-}"
+  local session=""
+
+  case "$command" in
+    new)
+      shift
+      cmd_new "$@"
+      ;;
+    open)
+      shift
+      cmd_open "$@"
+      ;;
+    ls)
+      shift
+      cmd_ls "$@"
+      ;;
+    rm)
+      shift
+      cmd_rm "$@"
+      ;;
+    refresh-status)
+      shift
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --session)
+            [[ $# -ge 2 ]] || die "--session requires a value"
+            session="${2:-}"
+            shift 2
+            ;;
+          *)
+            die "unknown option: $1"
+            ;;
+        esac
+      done
+      refresh_status "$session"
+      ;;
+    ""|-h|--help|help)
+      usage
+      ;;
+    *)
+      die "unknown command: $command"
+      ;;
+  esac
+}
+
+main "$@"

--- a/packages/bin/.local/bin/gwt-status-loop
+++ b/packages/bin/.local/bin/gwt-status-loop
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REFRESH_INTERVAL_SECONDS="${GWT_REFRESH_INTERVAL_SECONDS:-1}"
+MAX_CONSECUTIVE_FAILURES="${GWT_MAX_CONSECUTIVE_FAILURES:-3}"
+
+die() {
+  printf 'gwt-status-loop: %s\n' "$*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+script_dir() {
+  cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P
+}
+
+gwt_command() {
+  printf '%s/gwt\n' "$(script_dir)"
+}
+
+refresh_status() {
+  local session="$1"
+  local command
+
+  command="$(gwt_command)"
+  [[ -x "$command" ]] || die "required command not found: $command"
+  "$command" refresh-status --session "$session"
+}
+
+main() {
+  local session=""
+  local consecutive_failures=0
+
+  require_cmd tmux
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --session)
+        [[ $# -ge 2 ]] || die "--session requires a value"
+        session="${2:-}"
+        shift 2
+        ;;
+      *)
+        die "unknown option: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$session" ]] || die "--session is required"
+
+  while tmux has-session -t "$session" 2>/dev/null; do
+    if refresh_status "$session"; then
+      consecutive_failures=0
+    else
+      consecutive_failures=$((consecutive_failures + 1))
+      printf 'gwt-status-loop: refresh failed for session %s (%s/%s)\n' \
+        "$session" "$consecutive_failures" "$MAX_CONSECUTIVE_FAILURES" >&2
+      if (( consecutive_failures >= MAX_CONSECUTIVE_FAILURES )); then
+        die "stopping after repeated refresh failures"
+      fi
+    fi
+    sleep "$REFRESH_INTERVAL_SECONDS"
+  done
+}
+
+main "$@"

--- a/packages/lazygit/.config/lazygit/config.yml
+++ b/packages/lazygit/.config/lazygit/config.yml
@@ -6,9 +6,3 @@ git:
   paging:
     colorArg: always
     pager: delta --dark --paging=never
-customCommands:
-  - key: "W"
-    context: "localBranches"
-    description: "Create worktree (auto path: .worktrees/branch)"
-    command: 'git worktree add "$(git rev-parse --show-toplevel)/.worktrees/{{.SelectedLocalBranch.Name}}" {{.SelectedLocalBranch.Name}}'
-    loadingText: "Creating worktree..."

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -25,6 +25,9 @@ bind -r p previous-window
 # Use vi key bindings in copy mode
 setw -g mode-keys vi
 
+# Style tmux chooser modes such as the session list (`prefix + s`)
+setw -g mode-style 'bg=#89b4fa,fg=#1e1e2e,bold'
+
 # Start selection with 'v'
 bind -T copy-mode-vi v send -X begin-selection
 
@@ -33,17 +36,6 @@ bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'
 
 # Enter copy mode with mouse scrolling
 set -g mouse on
-
-# Apply my saved layout to the current window (prefix + L)
-bind L select-layout "e017,155x41,0,0{107x41,0,0[107x30,0,0,5,107x10,0,31,11],47x41,108,0,10}"
-
-# Sync all panes to the current pane's working directory (prefix + P)
-bind P run-shell '\
-  p="#{pane_current_path}"; \
-  tmux list-panes -F "##{pane_id} ##{pane_current_command}" | while read -r id cmd; do \
-    case "$cmd" in zsh|-zsh|bash|-bash|fish) tmux send-keys -t "$id" "cd -- \"$p\"" C-m ;; esac; \
-  done \
-'
 
 # Status bar settings (Catppuccin Mocha)
 set -g status-position bottom
@@ -56,10 +48,10 @@ set -g status-left-length 20
 
 # Window status display settings
 setw -g window-status-current-style bg='#313244',fg='#cdd6f4',bold
-setw -g window-status-current-format ' #I #W #{b:pane_current_path} '
+setw -g window-status-current-format ' #I #W '
 
 setw -g window-status-style fg='#6c7086',bg='#1e1e2e'
-setw -g window-status-format ' #I #W #{b:pane_current_path} '
+setw -g window-status-format ' #I #W '
 
 # Pane border color settings
 set -g pane-border-style bg='#1e1e2e',fg='#45475a'
@@ -70,6 +62,10 @@ set -sg escape-time 0
 
 # Use 256-color terminal
 set -g default-terminal "screen-256color"
+
+# Make the session chooser wider and more informative
+bind s choose-tree -Zs -O time \
+    -F '#{?session_attached,#[fg=#a6e3a1]● ,  }#[default]#{session_name} #[fg=#6c7086](#{session_windows} windows)#[default]'
 
 # TPM (Tmux Plugin Manager)
 set -g @plugin 'tmux-plugins/tpm'

--- a/packages/zsh/.config/zsh/.functions.zsh
+++ b/packages/zsh/.config/zsh/.functions.zsh
@@ -66,22 +66,6 @@ function gadd() {
   (( ${#files[@]} )) && git add -- "${files[@]}" && git status --short
 }
 
-# Git: remove worktrees (fzf multi-select)
-function gwtd() {
-  local -a worktrees
-  worktrees=("${(@f)$(git worktree list |
-             awk 'NR>1 {print}' |
-             fzf -m --preview 'git log --oneline -15 $(echo {} | awk "{print \$NF}" | tr -d "[]")')}") || return
-  (( ${#worktrees[@]} )) || return
-  for entry in "${worktrees[@]}"; do
-    local dir=$(echo "$entry" | awk '{print $1}')
-    local branch=$(echo "$entry" | awk '{print $NF}' | tr -d '[]')
-    echo "Removing worktree: $dir (branch: $branch)"
-    git worktree remove --force "$dir"
-    git branch -D "$branch" 2>/dev/null
-  done
-}
-
 # Zoxide interactive selection (Ctrl+z)
 function zoxide_interactive() {
   local dir=$(zoxide query -i)

--- a/tests/gwt-ls.sh
+++ b/tests/gwt-ls.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/ui.sh"
+
+GWT="${REPO_ROOT}/packages/bin/.local/bin/gwt"
+
+fail() {
+    warn "$*"
+    exit 1
+}
+
+test_ls_fails_cleanly_outside_git_repo() {
+    local temp_dir
+    local output
+    local rc
+
+    temp_dir="$(mktemp -d /tmp/gwt-ls-non-git.XXXXXX)"
+    temp_dir="$(cd "$temp_dir" && pwd -P)"
+
+    set +e
+    output="$(cd "$temp_dir" && "$GWT" ls 2>&1)"
+    rc=$?
+    set -e
+
+    [[ "$rc" -ne 0 ]] || fail "expected non-zero exit outside a git repository"
+    [[ "$output" == "gwt: not inside a git repository" ]] || fail "expected a single clean error message, got: $output"
+
+    rm -rf "$temp_dir"
+}
+
+main() {
+    step "Running gwt ls non-repository test"
+    test_ls_fails_cleanly_outside_git_repo
+    ok "ls fails cleanly outside a git repository"
+}
+
+main "$@"

--- a/tests/gwt-open.sh
+++ b/tests/gwt-open.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/ui.sh"
+
+GWT="${REPO_ROOT}/packages/bin/.local/bin/gwt"
+REAL_GIT="$(command -v git)"
+
+fail() {
+    warn "$*"
+    exit 1
+}
+
+meta_file_for_task() {
+    local repo_root="$1"
+    local task="$2"
+
+    printf '%s/.worktrees/.gwt/tasks/%s.tsv\n' \
+        "$repo_root" \
+        "$(printf '%s' "$task" | shasum | awk '{print $1}')"
+}
+
+setup_repo() {
+    local repo_root="$1"
+    local task="$2"
+    local metadata_branch="$3"
+    local actual_branch="$4"
+    local worktree_path="${repo_root}/.worktrees/${task}"
+    local metadata_file
+
+    repo_root="$(cd "$repo_root" && pwd -P)"
+    git init -q "$repo_root"
+    git -C "$repo_root" config user.name "Test User"
+    git -C "$repo_root" config user.email "test@example.com"
+
+    printf 'base\n' >"${repo_root}/README.md"
+    git -C "$repo_root" add README.md
+    git -C "$repo_root" commit -qm "Initial commit"
+
+    mkdir -p "${repo_root}/.worktrees/.gwt/tasks"
+    git -C "$repo_root" worktree add -q -b "$actual_branch" "$worktree_path"
+
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$task" \
+        "codex" \
+        "$worktree_path" \
+        "$metadata_branch" \
+        "$repo_root" >"$metadata_file"
+}
+
+write_tmux_wrapper() {
+    local wrapper_path="$1"
+
+    cat >"$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    has-session)
+        exit 1
+        ;;
+    new-session)
+        exit 0
+        ;;
+    list-windows)
+        exit 0
+        ;;
+    new-window)
+        printf '%%1\n'
+        ;;
+    list-panes)
+        printf '%%2\n'
+        ;;
+    split-window)
+        printf '%%3\n'
+        ;;
+    set-option|rename-window|select-layout|send-keys|select-pane|select-window|switch-client)
+        exit 0
+        ;;
+    *)
+        printf 'unexpected tmux command: %s\n' "$cmd" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$wrapper_path"
+}
+
+write_codex_wrapper() {
+    local wrapper_path="$1"
+
+    cat >"$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$wrapper_path"
+}
+
+test_open_rejects_stale_branch_without_force() {
+    local repo_root
+    local task="task-open-stale"
+    local output
+    local rc
+
+    repo_root="$(mktemp -d /tmp/gwt-open-stale.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "expected-branch" "actual-branch"
+
+    set +e
+    output="$(cd "$repo_root" && "$GWT" open "$task" 2>&1)"
+    rc=$?
+    set -e
+
+    [[ "$rc" -ne 0 ]] || fail "expected non-zero exit for stale metadata without --force"
+    [[ "$output" == *"metadata is stale"* ]] || fail "expected stale metadata error"
+    [[ "$output" == *"gwt open --force ${task}"* ]] || fail "expected recovery hint for --force"
+    rm -rf "$repo_root"
+}
+
+test_open_force_allows_stale_branch_after_warning() {
+    local repo_root
+    local task="task-open-force"
+    local wrapper_dir
+    local output
+
+    repo_root="$(mktemp -d /tmp/gwt-open-force.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+    wrapper_dir="$(mktemp -d /tmp/gwt-open-wrapper.XXXXXX)"
+    wrapper_dir="$(cd "$wrapper_dir" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "expected-branch" "actual-branch"
+    write_tmux_wrapper "${wrapper_dir}/tmux"
+    write_codex_wrapper "${wrapper_dir}/codex"
+
+    output="$(cd "$repo_root" && TMUX=1 PATH="${wrapper_dir}:$PATH" "$GWT" open --force "$task" 2>&1)"
+
+    [[ "$output" == *"warning: task ${task} metadata is stale"* ]] || fail "expected stale metadata warning"
+    [[ "$output" == *"continuing because --force was provided"* ]] || fail "expected force continuation warning"
+    rm -rf "$repo_root" "$wrapper_dir"
+}
+
+main() {
+    step "Running gwt open stale-metadata tests"
+    test_open_rejects_stale_branch_without_force
+    ok "open rejects stale branch metadata by default"
+    test_open_force_allows_stale_branch_after_warning
+    ok "open --force allows stale branch metadata after warning"
+}
+
+main "$@"

--- a/tests/gwt-rm.sh
+++ b/tests/gwt-rm.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/ui.sh"
+
+GWT="${REPO_ROOT}/packages/bin/.local/bin/gwt"
+
+fail() {
+    warn "$*"
+    exit 1
+}
+
+meta_file_for_task() {
+    local repo_root="$1"
+    local task="$2"
+
+    printf '%s/.worktrees/.gwt/tasks/%s.tsv\n' \
+        "$repo_root" \
+        "$(printf '%s' "$task" | shasum | awk '{print $1}')"
+}
+
+assert_exists() {
+    local path="$1"
+    [[ -e "$path" ]] || fail "expected path to exist: $path"
+}
+
+assert_not_exists() {
+    local path="$1"
+    [[ ! -e "$path" ]] || fail "expected path to be absent: $path"
+}
+
+assert_branch_exists() {
+    local repo_root="$1"
+    local branch="$2"
+
+    git -C "$repo_root" show-ref --verify --quiet "refs/heads/${branch}" ||
+        fail "expected branch to exist: $branch"
+}
+
+setup_repo() {
+    local repo_root="$1"
+    local task="$2"
+    local branch="$3"
+    local dirty="${4:-0}"
+    local worktree_path="${repo_root}/.worktrees/${task}"
+    local metadata_file
+
+    repo_root="$(cd "$repo_root" && pwd -P)"
+    git init -q "$repo_root"
+    git -C "$repo_root" config user.name "Test User"
+    git -C "$repo_root" config user.email "test@example.com"
+
+    printf 'base\n' >"${repo_root}/README.md"
+    git -C "$repo_root" add README.md
+    git -C "$repo_root" commit -qm "Initial commit"
+
+    mkdir -p "${repo_root}/.worktrees/.gwt/tasks"
+    git -C "$repo_root" worktree add -q -b "$branch" "$worktree_path"
+
+    printf '%s\n' "$branch" >"${worktree_path}/feature.txt"
+    git -C "$worktree_path" add feature.txt
+    git -C "$worktree_path" commit -qm "Feature commit"
+
+    if [[ "$dirty" == "1" ]]; then
+        printf 'dirty\n' >>"${worktree_path}/feature.txt"
+    fi
+
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$task" \
+        "codex" \
+        "$worktree_path" \
+        "$branch" \
+        "$repo_root" >"$metadata_file"
+}
+
+write_tmux_wrapper() {
+    local wrapper_path="$1"
+
+    cat >"$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    has-session)
+        exit 0
+        ;;
+    list-windows)
+        printf '%%1 task-remove\n'
+        ;;
+    kill-window)
+        exit 0
+        ;;
+    *)
+        printf 'unexpected tmux command: %s\n' "$cmd" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$wrapper_path"
+}
+
+test_rm_removes_metadata_and_worktree_but_keeps_branch() {
+    local repo_root
+    local task="task-rm"
+    local branch="task-rm"
+    local metadata_file
+
+    repo_root="$(mktemp -d /tmp/gwt-rm.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "$branch"
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+
+    cd "$repo_root"
+    "$GWT" rm "$task"
+
+    assert_not_exists "$metadata_file"
+    assert_not_exists "${repo_root}/.worktrees/${task}"
+    assert_branch_exists "$repo_root" "$branch"
+    rm -rf "$repo_root"
+}
+
+test_rm_rejects_dirty_worktree_without_force() {
+    local repo_root
+    local task="task-rm-dirty"
+    local branch="task-rm-dirty"
+    local metadata_file
+    local output
+    local rc
+
+    repo_root="$(mktemp -d /tmp/gwt-rm-dirty.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "$branch" 1
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+
+    set +e
+    output="$(cd "$repo_root" && "$GWT" rm "$task" 2>&1)"
+    rc=$?
+    set -e
+
+    [[ "$rc" -ne 0 ]] || fail "expected rm to fail for dirty worktree without --force"
+    [[ "$output" == *"worktree has uncommitted changes"* ]] || fail "expected dirty-worktree error"
+    [[ "$output" == *"gwt rm --force ${task}"* ]] || fail "expected recovery hint for --force"
+    assert_exists "$metadata_file"
+    assert_exists "${repo_root}/.worktrees/${task}"
+    assert_branch_exists "$repo_root" "$branch"
+    rm -rf "$repo_root"
+}
+
+test_rm_rejects_dirty_worktree_without_closing_tmux_window() {
+    local repo_root
+    local task="task-dirty-window"
+    local branch="task-dirty-window"
+    local wrapper_dir
+    local tmux_log
+    local output
+    local rc
+
+    repo_root="$(mktemp -d /tmp/gwt-rm-dirty-window.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+    wrapper_dir="$(mktemp -d /tmp/gwt-rm-dirty-window-wrapper.XXXXXX)"
+    wrapper_dir="$(cd "$wrapper_dir" && pwd -P)"
+    tmux_log="$(mktemp /tmp/gwt-rm-dirty-window-log.XXXXXX)"
+
+    setup_repo "$repo_root" "$task" "$branch" 1
+
+    cat >"${wrapper_dir}/tmux" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="\${1:-}"
+shift || true
+printf '%s\n' "\$cmd" >>"${tmux_log}"
+
+case "\$cmd" in
+    has-session)
+        exit 0
+        ;;
+    list-windows)
+        printf '%%1 %s\n' "${task}"
+        ;;
+    kill-window)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+EOF
+    chmod +x "${wrapper_dir}/tmux"
+
+    set +e
+    output="$(cd "$repo_root" && PATH="${wrapper_dir}:$PATH" "$GWT" rm "$task" 2>&1)"
+    rc=$?
+    set -e
+
+    [[ "$rc" -ne 0 ]] || fail "expected rm to fail for dirty worktree without --force when tmux session exists"
+    [[ "$output" == *"worktree has uncommitted changes"* ]] || fail "expected dirty-worktree error"
+    [[ ! -s "$tmux_log" ]] || fail "expected rm to abort before calling tmux, got: $(cat "$tmux_log")"
+    rm -rf "$repo_root" "$wrapper_dir" "$tmux_log"
+}
+
+test_rm_force_removes_dirty_worktree() {
+    local repo_root
+    local task="task-rm-force"
+    local branch="task-rm-force"
+    local metadata_file
+
+    repo_root="$(mktemp -d /tmp/gwt-rm-force.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "$branch" 1
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+
+    cd "$repo_root"
+    "$GWT" rm --force "$task"
+
+    assert_not_exists "$metadata_file"
+    assert_not_exists "${repo_root}/.worktrees/${task}"
+    assert_branch_exists "$repo_root" "$branch"
+    rm -rf "$repo_root"
+}
+
+test_rm_cleans_tmux_window_when_session_exists() {
+    local repo_root
+    local task="task-remove"
+    local branch="task-remove"
+    local metadata_file
+    local wrapper_dir
+
+    repo_root="$(mktemp -d /tmp/gwt-rm-tmux.XXXXXX)"
+    repo_root="$(cd "$repo_root" && pwd -P)"
+    wrapper_dir="$(mktemp -d /tmp/gwt-rm-tmux-wrapper.XXXXXX)"
+    wrapper_dir="$(cd "$wrapper_dir" && pwd -P)"
+
+    setup_repo "$repo_root" "$task" "$branch"
+    metadata_file="$(meta_file_for_task "$repo_root" "$task")"
+    write_tmux_wrapper "${wrapper_dir}/tmux"
+
+    cd "$repo_root"
+    PATH="${wrapper_dir}:$PATH" "$GWT" rm "$task"
+
+    assert_not_exists "$metadata_file"
+    assert_not_exists "${repo_root}/.worktrees/${task}"
+    assert_branch_exists "$repo_root" "$branch"
+    rm -rf "$repo_root" "$wrapper_dir"
+}
+
+main() {
+    step "Running gwt rm regression tests"
+    test_rm_removes_metadata_and_worktree_but_keeps_branch
+    ok "rm removes metadata and worktree while keeping the branch"
+    test_rm_rejects_dirty_worktree_without_force
+    ok "rm rejects dirty worktrees without --force"
+    test_rm_rejects_dirty_worktree_without_closing_tmux_window
+    ok "rm rejects dirty worktrees before touching tmux"
+    test_rm_force_removes_dirty_worktree
+    ok "rm --force removes dirty worktrees"
+    test_rm_cleans_tmux_window_when_session_exists
+    ok "rm cleans the tmux window when a session exists"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a `gwt` CLI for managing agent-focused git worktrees and tmux windows
- add regression scripts covering `gwt ls`, `gwt open`, and `gwt rm`
- document the workflow and simplify related tmux/lazygit/zsh configuration

## Verification
- bash tests/gwt-ls.sh
- bash tests/gwt-open.sh
- bash tests/gwt-rm.sh
- bash -n packages/bin/.local/bin/gwt
- bash -n packages/bin/.local/bin/gwt-status-loop
- bash -n tests/gwt-ls.sh tests/gwt-open.sh tests/gwt-rm.sh