### PR TITLE
Refine gwt root session

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ Custom location: set `DOTFILES_DIR` before running tasks, e.g.
 - AI agent worktrees:
   - Requires `tmux`; after `./install.sh`, use `gwt` from `~/.local/bin/gwt`
   - Requires the selected agent CLI on `PATH` (`codex`, `claude`, or `copilot`); `gwt add` and `gwt open` validate it before opening the task window
-  - New project sessions start with window `1` named `@root` for repo-level shell work, overview, and non-worktree commands
+  - New project sessions start with window `1` named `<repo>@root` for repo-level shell work and as the parent-worktree hub for creating more task worktrees
   - `task` names are restricted to letters, numbers, `.`, `_`, and `-` (for example `tmux-status`); names like `feat/tmux-status` are rejected
   - `gwt add <task> --agent <codex|claude|copilot>` creates a new `.worktrees/<task>` plus a tmux window in the project session
   - `gwt open <task>` reopens an existing task window for a task recorded in `gwt` metadata and works across tmux sessions
   - `gwt open --force <task>` bypasses stale branch-metadata checks after warning; use it only for recovery when the recorded branch no longer matches the registered worktree branch
   - `gwt ls` shows `task / agent / status / dirty / worktree / stale`
   - `stale=yes` means the recorded metadata no longer matches reality (for example the worktree is missing or no longer registered on the recorded branch)
-  - `gwt rm <task>` closes the window and removes the worktree for a `gwt`-managed task; it refuses dirty worktrees, and local branches are left alone
+  - `gwt rm <task>` closes the task window and removes the worktree for a `gwt`-managed task; it refuses dirty worktrees, leaves the parent `<repo>@root` window/session alone, and local branches are left alone
   - `gwt rm --force <task>` also discards uncommitted changes in that worktree; use it only for recovery
   - `gwt` treats `.worktrees/.gwt/tasks/*.tsv` as the source of truth for managed tasks; if that metadata is missing, the task no longer appears in `gwt ls` and must be inspected or cleaned up with raw `git worktree` commands
   - Useful recovery commands for orphaned worktrees: `git worktree list`, `git worktree remove .worktrees/<task>`, and `git branch -d <branch>` when you also want to drop the branch

--- a/packages/bin/.local/bin/gwt
+++ b/packages/bin/.local/bin/gwt
@@ -48,7 +48,11 @@ repo_root() {
 }
 
 root_window_label() {
-  printf '%s\n' '@root'
+  printf '%s@root\n' "$(project_name)"
+}
+
+root_window_name() {
+  root_window_label
 }
 
 project_name() {
@@ -176,10 +180,17 @@ pane_has_agent_process() {
   local pane_id="$1"
   local agent="$2"
   local expected_cmd
+ 
+  expected_cmd="$(agent_command_name "$agent")"
+  pane_has_process_command "$pane_id" "$expected_cmd"
+}
+
+pane_has_process_command() {
+  local pane_id="$1"
+  local expected_cmd="$2"
   local tty
   local process_list
 
-  expected_cmd="$(agent_command_name "$agent")"
   tty="$(tmux display-message -p -t "$pane_id" '#{pane_tty}' 2>/dev/null || true)"
   [[ -n "$tty" ]] || return 1
 
@@ -216,6 +227,13 @@ find_window_by_task() {
 
   tmux list-windows -t "$session" -F '#{window_id}	#{@gwt_task}' 2>/dev/null |
     awk -F '\t' -v task="$task" '$2 == task { print $1; exit }'
+}
+
+find_root_window() {
+  local session="$1"
+
+  tmux list-windows -t "$session" -F '#{window_id}	#{window_name}	#{@gwt_task}' 2>/dev/null |
+    awk -F '\t' '$2 ~ /(^|.*)@root(\s\[.*\])?$/ && $3 == "" { print $1; exit }'
 }
 
 is_dirty_worktree() {
@@ -262,10 +280,15 @@ registered_worktree_for_task() {
 ensure_session() {
   local session="$1"
   local root="$2"
+  local root_window_id
 
   if ! tmux has-session -t "$session" 2>/dev/null; then
     tmux new-session -d -s "$session" -c "$root" -n "$(root_window_label)"
   fi
+
+  root_window_id="$(find_root_window "$session")"
+  [[ -n "$root_window_id" ]] || die "root window missing in session: $session"
+  tmux rename-window -t "$root_window_id" "$(root_window_name)"
 
   ensure_status_refresher "$session"
 }
@@ -286,17 +309,11 @@ ensure_status_refresher() {
 cleanup_session_if_idle() {
   local session="$1"
   local task_window_count
-  local window_count
 
   tmux has-session -t "$session" 2>/dev/null || return 0
 
   task_window_count="$(tmux list-windows -t "$session" -F '#{@gwt_task}' 2>/dev/null | awk 'NF { count++ } END { print count + 0 }')"
   [[ "$task_window_count" == "0" ]] || return 0
-
-  window_count="$(tmux list-windows -t "$session" 2>/dev/null | wc -l | tr -d ' ')"
-  [[ "$window_count" == "1" ]] || return 0
-
-  tmux kill-session -t "$session"
 }
 
 prepare_window_layout() {

--- a/tests/gwt-open.sh
+++ b/tests/gwt-open.sh
@@ -72,7 +72,7 @@ case "$cmd" in
         exit 0
         ;;
     list-windows)
-        exit 0
+        printf '%%root\tproject@root\t\n'
         ;;
     new-window)
         printf '%%1\n'


### PR DESCRIPTION
## Summary
- rename the root tmux window to <repo>@root and keep the session alive after removing the last task
- update gwt session handling to find and preserve the dedicated root window
- refresh README and tmux wrapper tests to match the new root-window behavior

## Testing
- bash tests/gwt-open.sh
- bash tests/gwt-rm.sh
- bash tests/gwt-ls.sh