### PR TITLE
Improve gwt completions

### DIFF
--- a/packages/bin/.local/bin/gwt
+++ b/packages/bin/.local/bin/gwt
@@ -7,14 +7,25 @@ STATUS_IDLE_SECONDS="${GWT_STATUS_IDLE_SECONDS:-2}"
 usage() {
   cat <<'EOF'
 Usage:
-  gwt add <task> --agent <codex|claude|copilot> [--branch <branch>] [--base <branch>]
-  gwt open [--force] <task>
+  gwt add --agent <agent> [--branch <branch>] [--base <branch>] <task-name>
+  gwt open [--force] <task-name>
   gwt ls
-  gwt rm [--force] <task>
+  gwt rm [--force] <task-name>
+
+Examples:
+  gwt add --agent codex feature-login
+  gwt add --agent claude --branch feat/login-ui ui-login
+  gwt add --agent copilot --base main hotfix-123
+  gwt open --force feature-login
 
 Notes:
+  - options may be passed before or after <task-name>
+  - <task-name> controls the worktree directory, tmux window label, and metadata key
+  - --branch overrides the git branch name; the task name still controls gwt's internal naming
+  - --base is only used when creating a new branch; if --branch already exists, gwt reuses it
   - gwt metadata under .worktrees/.gwt/tasks/*.tsv is the source of truth for managed tasks
   - if metadata is missing, the task will not appear in 'gwt ls'; inspect or clean it up with 'git worktree list' and 'git worktree remove .worktrees/<task>'
+  - internal commands such as 'refresh-status' are omitted from this help
 EOF
 }
 
@@ -153,27 +164,112 @@ load_task_metadata() {
   [[ "$task" == "$requested_task" ]] || die "metadata task mismatch: $file"
 }
 
+list_agents() {
+  cat <<'EOF'
+codex	OpenAI Codex
+claude	Anthropic Claude
+copilot	GitHub Copilot
+EOF
+}
+
+agent_exists() {
+  local requested_agent="$1"
+
+  list_agents | awk -F '\t' -v requested_agent="$requested_agent" '$1 == requested_agent { found = 1 } END { exit(found ? 0 : 1) }'
+}
+
 agent_command() {
-  case "$1" in
-    codex)
-      printf '%s\n' "codex"
-      ;;
-    claude)
-      printf '%s\n' "claude"
-      ;;
-    copilot)
-      printf '%s\n' "copilot"
-      ;;
-    *)
-      die "unsupported agent: $1"
-      ;;
-  esac
+  agent_exists "$1" || die "unsupported agent: $1"
+  printf '%s\n' "$1"
 }
 
 agent_command_name() {
-  local command
-  command="$(agent_command "$1")"
-  printf '%s\n' "${command%% *}"
+  agent_command "$1" | awk '{print $1}'
+}
+
+set_single_task_argument() {
+  local var_name="$1"
+  local value="$2"
+  local current_value="${!var_name:-}"
+
+  if [[ -z "$current_value" ]]; then
+    printf -v "$var_name" '%s' "$value"
+  else
+    die "unexpected extra argument: $value"
+  fi
+}
+
+parse_task_and_force_args() {
+  local task_var_name="$1"
+  local force_var_name="$2"
+
+  shift 2
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)
+        printf -v "$force_var_name" '1'
+        shift
+        ;;
+      --)
+        shift
+        while [[ $# -gt 0 ]]; do
+          set_single_task_argument "$task_var_name" "$1"
+          shift
+        done
+        ;;
+      -*)
+        die "unknown option: $1"
+        ;;
+      *)
+        set_single_task_argument "$task_var_name" "$1"
+        shift
+        ;;
+    esac
+  done
+}
+
+parse_add_args() {
+  local task_var_name="$1"
+  local agent_var_name="$2"
+  local branch_var_name="$3"
+  local base_var_name="$4"
+
+  shift 4
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        [[ $# -ge 2 ]] || die "--agent requires a value"
+        printf -v "$agent_var_name" '%s' "${2:-}"
+        shift 2
+        ;;
+      --branch)
+        [[ $# -ge 2 ]] || die "--branch requires a value"
+        printf -v "$branch_var_name" '%s' "${2:-}"
+        shift 2
+        ;;
+      --base)
+        [[ $# -ge 2 ]] || die "--base requires a value"
+        printf -v "$base_var_name" '%s' "${2:-}"
+        shift 2
+        ;;
+      --)
+        shift
+        while [[ $# -gt 0 ]]; do
+          set_single_task_argument "$task_var_name" "$1"
+          shift
+        done
+        ;;
+      -*)
+        die "unknown option: $1"
+        ;;
+      *)
+        set_single_task_argument "$task_var_name" "$1"
+        shift
+        ;;
+    esac
+  done
 }
 
 pane_has_agent_process() {
@@ -479,7 +575,7 @@ refresh_status() {
 }
 
 cmd_add() {
-  local task="${1:-}"
+  local task=""
   local agent=""
   local agent_cmd=""
   local branch=""
@@ -513,32 +609,9 @@ cmd_add() {
   GWT_ADD_CREATED_WORKTREE="0"
   GWT_ADD_CREATED_METADATA="0"
 
+  parse_add_args task agent branch base "$@"
+
   validate_task_name "$task"
-  shift || true
-
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --agent)
-        [[ $# -ge 2 ]] || die "--agent requires a value"
-        agent="${2:-}"
-        shift 2
-        ;;
-      --branch)
-        [[ $# -ge 2 ]] || die "--branch requires a value"
-        branch="${2:-}"
-        shift 2
-        ;;
-      --base)
-        [[ $# -ge 2 ]] || die "--base requires a value"
-        base="${2:-}"
-        shift 2
-        ;;
-      *)
-        die "unknown option: $1"
-        ;;
-    esac
-  done
-
   [[ -n "$agent" ]] || die "--agent is required"
   require_cmd git
   require_cmd tmux
@@ -603,26 +676,9 @@ cmd_open() {
   local agent_cmd=""
   local actual_branch=""
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --force)
-        force="1"
-        shift
-        ;;
-      *)
-        if [[ -z "$task" ]]; then
-          task="$1"
-          shift
-        else
-          die "unknown option: $1"
-        fi
-        ;;
-    esac
-  done
+  parse_task_and_force_args task force "$@"
 
   validate_task_name "$task"
-
-  [[ $# -eq 0 ]] || die "unknown option: $1"
 
   require_cmd git
   require_cmd tmux
@@ -722,22 +778,7 @@ cmd_rm() {
   local metadata_file=""
   local dirty="no"
 
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --force)
-        force="1"
-        shift
-        ;;
-      *)
-        if [[ -z "$task" ]]; then
-          task="$1"
-          shift
-        else
-          die "unknown option: $1"
-        fi
-        ;;
-    esac
-  done
+  parse_task_and_force_args task force "$@"
 
   validate_task_name "$task"
   require_cmd git
@@ -794,7 +835,7 @@ main() {
       shift
       cmd_rm "$@"
       ;;
-    refresh-status)
+    refresh-status|__refresh-status)
       shift
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -809,6 +850,11 @@ main() {
         esac
       done
       refresh_status "$session"
+      ;;
+    __list-agents)
+      shift
+      [[ $# -eq 0 ]] || die "unknown option: $1"
+      list_agents
       ;;
     ""|-h|--help|help)
       usage

--- a/packages/bin/.local/bin/gwt-status-loop
+++ b/packages/bin/.local/bin/gwt-status-loop
@@ -28,7 +28,7 @@ refresh_status() {
 
   command="$(gwt_command)"
   [[ -x "$command" ]] || die "required command not found: $command"
-  "$command" refresh-status --session "$session"
+  "$command" __refresh-status --session "$session"
 }
 
 main() {

--- a/packages/zsh/.config/zsh/.functions.zsh
+++ b/packages/zsh/.config/zsh/.functions.zsh
@@ -10,8 +10,44 @@ function lg() {
 
 # Git: delete merged branches
 function gbdm() {
+  local default_branch=""
+  local base_ref=""
+  local current_branch=""
+  local -a branches
+
   git fetch --prune
-  git branch --merged | egrep -v "\*|master|main|development" | xargs git branch -d
+
+  default_branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  default_branch="${default_branch#origin/}"
+
+  if [[ -n "$default_branch" ]] && git rev-parse --verify "refs/remotes/origin/${default_branch}" >/dev/null 2>&1; then
+    base_ref="refs/remotes/origin/${default_branch}"
+  elif git rev-parse --verify "refs/heads/main" >/dev/null 2>&1; then
+    default_branch="main"
+    base_ref="refs/heads/main"
+  elif git rev-parse --verify "refs/remotes/origin/main" >/dev/null 2>&1; then
+    default_branch="main"
+    base_ref="refs/remotes/origin/main"
+  elif git rev-parse --verify "refs/heads/master" >/dev/null 2>&1; then
+    default_branch="master"
+    base_ref="refs/heads/master"
+  elif git rev-parse --verify "refs/remotes/origin/master" >/dev/null 2>&1; then
+    default_branch="master"
+    base_ref="refs/remotes/origin/master"
+  else
+    printf 'gbdm: could not determine default branch\n' >&2
+    return 1
+  fi
+
+  current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  branches=("${(@f)$(git for-each-ref --format='%(refname:short)' --merged "$base_ref" refs/heads | grep -E -v "^(${default_branch}|main|master|development)$" || true)}")
+
+  if [[ -n "$current_branch" ]]; then
+    branches=("${(@)branches:#$current_branch}")
+  fi
+
+  (( ${#branches[@]} )) || return 0
+  git branch -d -- "${branches[@]}"
 }
 
 # Git: switch to local branch (fzf)
@@ -29,41 +65,6 @@ function gswr() {
            grep -v HEAD |
            fzf --preview 'git log --oneline -15 {1}') || return
   git switch "${branch#origin/}"
-}
-
-# Git: force delete branches (fzf multi-select)
-function gbd() {
-  local -a branches
-  branches=("${(@f)$(git for-each-ref --format='%(refname:short)' refs/heads | fzf -m)}") || return
-  (( ${#branches[@]} )) && git branch -D -- "${branches[@]}"
-}
-
-# Git: browse log (fzf)
-function glog() {
-  git log --oneline --color=always |
-    fzf --ansi --no-sort \
-        --preview 'git show --color=always {1}' \
-        --preview-window=right:60% \
-        --bind 'enter:execute(git show --color=always {1} | less -R)'
-}
-
-# Git: browse and apply stash (fzf)
-function gstash() {
-  local stash
-  stash=$(git stash list |
-          fzf --preview 'git stash show -p --color=always $(echo {} | cut -d: -f1)' \
-              --preview-window=right:60%) || return
-  local stash_ref=$(echo "$stash" | cut -d: -f1)
-  echo "Apply $stash_ref? [y/N] "
-  read -q && git stash apply "$stash_ref"
-}
-
-# Git: interactive add (fzf multi-select)
-function gadd() {
-  local -a files
-  files=("${(@f)$(git diff --name-only |
-         fzf -m --preview 'git diff --color=always -- {}')}") || return
-  (( ${#files[@]} )) && git add -- "${files[@]}" && git status --short
 }
 
 # Zoxide interactive selection (Ctrl+z)

--- a/packages/zsh/.config/zsh/.options.zsh
+++ b/packages/zsh/.config/zsh/.options.zsh
@@ -4,6 +4,8 @@ setopt IGNOREEOF correct no_flow_control
 autoload -Uz colors && colors
 
 # Completion
+# Register local completion functions before initializing zsh completion.
+fpath=("$ZSHDIR/completions" $fpath)
 autoload -Uz compinit && compinit
 setopt complete_aliases
 autoload -Uz select-word-style && select-word-style default

--- a/packages/zsh/.config/zsh/completions/_gwt
+++ b/packages/zsh/.config/zsh/completions/_gwt
@@ -1,0 +1,172 @@
+#compdef gwt
+
+_gwt_agents() {
+  local -a agents
+  agents=(${(f)"$(gwt __list-agents 2>/dev/null | awk -F $'\t' '{ print $1 }')"})
+  (( ${#agents[@]} )) || return 1
+  compadd -- "${agents[@]}"
+}
+
+_gwt_branches() {
+  local -a branches
+
+  command git rev-parse --git-dir >/dev/null 2>&1 || return 1
+  branches=(${(f)"$(git for-each-ref --format='%(refname:short)' refs/heads 2>/dev/null)"})
+  (( ${#branches[@]} )) || return 1
+  compadd -- "${branches[@]}"
+}
+
+_gwt_task_names() {
+  setopt local_options null_glob
+  local root metadata_dir
+  local -a metadata_files
+
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  metadata_dir="${root}/.worktrees/.gwt/tasks"
+  [[ -d "$metadata_dir" ]] || return 1
+
+  metadata_files=("$metadata_dir"/*.tsv)
+  (( ${#metadata_files[@]} )) || return 1
+
+  awk -F $'\t' 'NF { print $1 }' "${metadata_files[@]}" 2>/dev/null
+}
+
+_gwt_tasks() {
+  local -a tasks
+
+  tasks=(${(f)"$(_gwt_task_names)"})
+  (( ${#tasks[@]} )) || return 1
+  compadd -- "${tasks[@]}"
+}
+
+_gwt_add_has_task() {
+  local word
+  local expecting_value=""
+
+  for word in "${words[@]:3}"; do
+    [[ "$word" == "$PREFIX" ]] && continue
+
+    if [[ -n "$expecting_value" ]]; then
+      expecting_value=""
+      continue
+    fi
+
+    case "$word" in
+      --agent|--branch|--base)
+        expecting_value="1"
+        ;;
+      --*)
+        ;;
+      *)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+_gwt_open_rm_has_task() {
+  local word
+
+  for word in "${words[@]:3}"; do
+    [[ "$word" == "$PREFIX" ]] && continue
+
+    case "$word" in
+      --force|--*)
+        ;;
+      *)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+_gwt_has_option() {
+  local option="$1"
+  local word
+
+  for word in "${words[@]:2}"; do
+    [[ "$word" == "$option" ]] && return 0
+  done
+
+  return 1
+}
+
+_gwt_complete_add() {
+  local previous_word="${words[CURRENT-1]:-}"
+  local -a options
+
+  case "$previous_word" in
+    --agent)
+      _gwt_agents
+      return
+      ;;
+    --branch|--base)
+      _gwt_branches
+      return
+      ;;
+  esac
+
+  options=(--agent --branch --base)
+  _gwt_has_option --agent && options=("${(@)options:#--agent}")
+  _gwt_has_option --branch && options=("${(@)options:#--branch}")
+  _gwt_has_option --base && options=("${(@)options:#--base}")
+
+  if [[ -z "$PREFIX" || "$PREFIX" == -* ]]; then
+    (( ${#options[@]} )) && compadd -- "${options[@]}"
+    return
+  fi
+
+  if ! _gwt_add_has_task; then
+    return 0
+  fi
+}
+
+_gwt_complete_open_or_rm() {
+  local -a options
+
+  options=(--force)
+  _gwt_has_option --force && options=()
+
+  if [[ -z "$PREFIX" || "$PREFIX" == -* ]]; then
+    (( ${#options[@]} )) && compadd -- "${options[@]}"
+    _gwt_tasks
+    return
+  fi
+
+  _gwt_tasks
+}
+
+_gwt() {
+  local subcommand="${words[2]:-}"
+  local -a commands
+
+  commands=(add open ls rm help)
+
+  if (( CURRENT == 2 )); then
+    compadd -- "${commands[@]}"
+    return
+  fi
+
+  case "$subcommand" in
+    add)
+      _gwt_complete_add
+      ;;
+    open)
+      _gwt_complete_open_or_rm
+      ;;
+    rm)
+      _gwt_complete_open_or_rm
+      ;;
+    ls|help)
+      ;;
+    *)
+      compadd -- "${commands[@]}"
+      ;;
+  esac
+}
+
+_gwt "$@"


### PR DESCRIPTION
## Summary
- add zsh completion support for `gwt` and register local completion functions
- make `gwt` argument parsing more flexible and hide internal subcommands from the public CLI
- improve `gbdm` default-branch detection and remove unused interactive git helpers from personal dotfiles

## Verification
- `bash -n packages/bin/.local/bin/gwt packages/bin/.local/bin/gwt-status-loop`
- `zsh -n packages/zsh/.config/zsh/.functions.zsh packages/zsh/.config/zsh/.options.zsh packages/zsh/.config/zsh/completions/_gwt`