### PR TITLE
Fix shell keybindings

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -52,7 +52,7 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 
 ### tmux
 
-`prefix` is the tmux default (`Ctrl + b`).
+`prefix` is `Ctrl + a`.
 
 | Key | Action | Source |
 |---|---|---|
@@ -60,6 +60,8 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 | `prefix + -` | Split pane horizontally (keep cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + H/J/K/L` | Resize pane | `packages/tmux/.tmux.conf` |
 | `prefix + t` | New window (keep cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + u` | Open a shell in a centered tmux popup | `packages/tmux/.tmux.conf` |
+| `prefix + g` | Open `lazygit` in centered tmux popup | `packages/tmux/.tmux.conf` |
 | `prefix + n/p` | Next/previous window | `packages/tmux/.tmux.conf` |
 | `prefix + s` | Open session chooser (`choose-tree`) | `packages/tmux/.tmux.conf` |
 | `copy-mode` + `v` | Begin selection | `packages/tmux/.tmux.conf` |

--- a/packages/starship/.config/starship.toml
+++ b/packages/starship/.config/starship.toml
@@ -18,6 +18,7 @@ truncate_to_repo = true
 [character]
 success_symbol = "[❯](bold #94e2d5)"
 error_symbol = "[❯](bold #f38ba8)"
+vicmd_symbol = "[N](bold #f9e2af)"
 
 [git_branch]
 format = "[$symbol$branch]($style)"

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -2,6 +2,11 @@
 set-option -g base-index 1
 set-option -g pane-base-index 1
 
+# Free Ctrl+b for shell backward-char and use Ctrl+a as the tmux prefix.
+unbind C-b
+set-option -g prefix C-a
+bind-key C-a send-prefix
+
 # Automatic renumbering of pane and window numbers
 set-option -g renumber-windows on
 
@@ -17,6 +22,8 @@ bind -r L resize-pane -R 5
 
 # Create new window in current directory
 bind t new-window -c "#{pane_current_path}"
+bind u display-popup -d "#{pane_current_path}" -xC -yC -w 85% -h 85% -E
+bind g display-popup -d "#{pane_current_path}" -xC -yC -w 85% -h 85% -E "lazygit"
 
 # Moving windows
 bind -r n next-window

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -2,7 +2,6 @@
 set-option -g base-index 1
 set-option -g pane-base-index 1
 
-# Free Ctrl+b for shell backward-char and use Ctrl+a as the tmux prefix.
 unbind C-b
 set-option -g prefix C-a
 bind-key C-a send-prefix

--- a/packages/zsh/.config/zsh/.options.zsh
+++ b/packages/zsh/.config/zsh/.options.zsh
@@ -1,5 +1,5 @@
 # Shell basics
-bindkey -e
+bindkey -v
 setopt IGNOREEOF correct no_flow_control
 autoload -Uz colors && colors
 
@@ -21,6 +21,8 @@ HISTSIZE=10000
 SAVEHIST=10000
 bindkey "^p" history-substring-search-up
 bindkey "^n" history-substring-search-down
+bindkey -M viins "^?" backward-delete-char
+bindkey -M viins "^H" backward-delete-char
 
 # Directory navigation
 setopt auto_cd auto_pushd pushd_ignore_dups


### PR DESCRIPTION
## Summary
- Change tmux prefix to Ctrl+a and document it
- Add tmux popup bindings for shell and lazygit
- Enable zsh vi keybindings and show vi command mode in starship

## Tests
- Not run (configuration-only changes)