### PR TITLE
Refine nvim UI

### DIFF
--- a/packages/nvim/.config/nvim/lua/config/base-options.lua
+++ b/packages/nvim/.config/nvim/lua/config/base-options.lua
@@ -21,7 +21,19 @@ vim.opt.foldmethod = "indent"
 vim.opt.foldlevel = 99
 vim.opt.foldenable = true
 vim.opt.foldcolumn = "1"
-vim.opt.fillchars = { fold = " ", foldopen = "▾", foldclose = "▸", foldsep = " " }
+vim.opt.fillchars = {
+  fold = " ",
+  foldopen = "▾",
+  foldclose = "▸",
+  foldsep = " ",
+  horiz = "─",
+  horizdown = "┬",
+  horizup = "┴",
+  vert = "│",
+  verthoriz = "┼",
+  vertleft = "┤",
+  vertright = "├",
+}
 vim.opt.foldtext = "foldtext()"
 vim.opt.encoding = "utf-8"
 vim.opt.backup = false

--- a/packages/nvim/.config/nvim/lua/plugins/colorscheme.lua
+++ b/packages/nvim/.config/nvim/lua/plugins/colorscheme.lua
@@ -16,6 +16,8 @@ return {
           DiffAdd = { fg = colors.green },
           DiffDelete = { fg = colors.red },
           DiffText = { fg = colors.blue },
+          NvimTreeWinSeparator = { fg = colors.overlay1 },
+          WinSeparator = { fg = colors.overlay1 },
         }
       end,
     })

--- a/packages/nvim/.config/nvim/lua/plugins/diffview.lua
+++ b/packages/nvim/.config/nvim/lua/plugins/diffview.lua
@@ -40,7 +40,7 @@ return {
         },
         merge_tool = {
           -- Config for conflicted files in diff views during a merge or rebase.
-          layout = "diff3_horizontal",
+          layout = "diff3_mixed",
           disable_diagnostics = true,   -- Temporarily disable diagnostics for diff buffers while in the view.
           winbar_info = true,           -- See |diffview-config-view.x.winbar_info|
         },
@@ -59,7 +59,7 @@ return {
         },
         win_config = {                      -- See |diffview-config-win_config|
           position = "left",
-          width = 35,
+          width = 28,
           win_opts = {},
         },
       },
@@ -104,8 +104,7 @@ return {
           { "n", "gf",          actions.goto_file_edit,                 { desc = "Open the file in the previous tabpage" } },
           { "n", "<C-w><C-f>",  actions.goto_file_split,                { desc = "Open the file in a new split" } },
           { "n", "<C-w>gf",     actions.goto_file_tab,                  { desc = "Open the file in a new tabpage" } },
-          { "n", "<leader>e",   actions.focus_files,                    { desc = "Bring focus to the file panel" } },
-          { "n", "<leader>b",   actions.toggle_files,                   { desc = "Toggle the file panel." } },
+          { "n", "<leader>e",   actions.toggle_files,                   { desc = "Toggle the file panel." } },
           { "n", "g<C-x>",      actions.cycle_layout,                   { desc = "Cycle through available layouts." } },
           { "n", "[x",          actions.prev_conflict,                  { desc = "In the merge-tool: jump to the previous conflict" } },
           { "n", "]x",          actions.next_conflict,                  { desc = "In the merge-tool: jump to the next conflict" } },
@@ -174,8 +173,7 @@ return {
           { "n", "i",              actions.listing_style,                  { desc = "Toggle between 'list' and 'tree' views" } },
           { "n", "f",              actions.toggle_flatten_dirs,            { desc = "Flatten empty subdirectories in tree listing style" } },
           { "n", "R",              actions.refresh_files,                  { desc = "Update stats and entries in the file list" } },
-          { "n", "<leader>e",      actions.focus_files,                    { desc = "Bring focus to the file panel" } },
-          { "n", "<leader>b",      actions.toggle_files,                   { desc = "Toggle the file panel" } },
+          { "n", "<leader>e",      actions.toggle_files,                   { desc = "Toggle the file panel" } },
           { "n", "g<C-x>",         actions.cycle_layout,                   { desc = "Cycle available layouts" } },
           { "n", "[x",             actions.prev_conflict,                  { desc = "Go to the previous conflict" } },
           { "n", "]x",             actions.next_conflict,                  { desc = "Go to the next conflict" } },
@@ -215,8 +213,7 @@ return {
           { "n", "gf",            actions.goto_file_edit,              { desc = "Open the file in the previous tabpage" } },
           { "n", "<C-w><C-f>",    actions.goto_file_split,             { desc = "Open the file in a new split" } },
           { "n", "<C-w>gf",       actions.goto_file_tab,               { desc = "Open the file in a new tabpage" } },
-          { "n", "<leader>e",     actions.focus_files,                 { desc = "Bring focus to the file panel" } },
-          { "n", "<leader>b",     actions.toggle_files,                { desc = "Toggle the file panel" } },
+          { "n", "<leader>e",     actions.toggle_files,                { desc = "Toggle the file panel" } },
           { "n", "g<C-x>",        actions.cycle_layout,                { desc = "Cycle available layouts" } },
           { "n", "g?",            actions.help("file_history_panel"),  { desc = "Open the help panel" } },
         },

--- a/packages/nvim/.config/nvim/lua/plugins/lualine.lua
+++ b/packages/nvim/.config/nvim/lua/plugins/lualine.lua
@@ -2,9 +2,18 @@ return {
   "nvim-lualine/lualine.nvim",
   dependencies = { "nvim-tree/nvim-web-devicons" },
   config = function()
+    local colors = require("catppuccin.palettes").get_palette("mocha")
+    local theme = require("lualine.themes.catppuccin-nvim")
+
+    local statusline_bg = colors.surface0
+    for _, mode in ipairs({ "normal", "insert", "visual", "replace", "command", "terminal", "inactive" }) do
+      theme[mode].c = theme[mode].c or {}
+      theme[mode].c.bg = statusline_bg
+    end
+
     require("lualine").setup({
       options = {
-        theme = "catppuccin-nvim",
+        theme = theme,
         component_separators = { left = "", right = "" },
         section_separators = { left = "", right = "" },
         disabled_filetypes = {

--- a/packages/nvim/.config/nvim/lua/plugins/nvim-cmp.lua
+++ b/packages/nvim/.config/nvim/lua/plugins/nvim-cmp.lua
@@ -17,6 +17,7 @@ return {
     vim.lsp.config.bashls = {
       cmd = { "bash-language-server", "start" },
       capabilities = defaultCapabilities,
+      filetypes = { "sh", "bash" },
       settings = {
         bashIde = {
           globPattern = "**/*@(.sh|.inc|.bash|.command)",
@@ -66,7 +67,7 @@ return {
 
         -- Documentation
         vim.keymap.set("n", "K", vim.lsp.buf.hover, opts)
-        vim.keymap.set("n", "<C-k>", vim.lsp.buf.signature_help, opts)
+        vim.keymap.set("n", "<leader>k", vim.lsp.buf.signature_help, opts)
 
         -- Code actions
         vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, opts)


### PR DESCRIPTION
## Summary
- adjust Neovim separators and statusline colors for the Catppuccin theme
- tune Diffview merge layout, panel width, and file panel toggle keymap
- narrow bashls filetypes and move signature help to <leader>k

## Test
- nvim --headless startup check via diff-refine