### PR TITLE
Record Claude cwd via hooks for tmux-open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ There is no single unified automated test suite for the whole repo, but there ar
 
 Use the narrowest validation that matches your change:
 - `bash tests/claude-statusline.sh`
+- `bash tests/claude-cwd-state-hook.sh`
 - `bash tests/tmux-open.sh`
 - `./scripts/check-updates.sh --list` for CLI/script sanity
 - `./install.sh` when you change installation flow, symlinking behavior, package lists, or anything cross-cutting

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -57,13 +57,13 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 
 | Key | Action | Source |
 |---|---|---|
-| `prefix + \|` | Split pane vertically (preferred cwd) | `packages/tmux/.tmux.conf` |
-| `prefix + -` | Split pane horizontally (preferred cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + \|` | Split pane vertically (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + -` | Split pane horizontally (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + H/J/K/L` | Resize pane | `packages/tmux/.tmux.conf` |
-| `prefix + t` | New window (preferred cwd) | `packages/tmux/.tmux.conf` |
-| `prefix + u` | Open a shell in a centered tmux popup (preferred cwd) | `packages/tmux/.tmux.conf` |
-| `prefix + g` | Open `lazygit` in centered tmux popup (preferred cwd) | `packages/tmux/.tmux.conf` |
-| `prefix + G` | Open `lazygit` in a bottom pane (preferred cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + t` | New window (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + u` | Open a shell in a centered tmux popup (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + g` | Open `lazygit` in centered tmux popup (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + G` | Open `lazygit` in a bottom pane (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + n/p` | Next/previous window | `packages/tmux/.tmux.conf` |
 | `prefix + s` | Open session chooser (`choose-tree`) | `packages/tmux/.tmux.conf` |
 | `copy-mode` + `v` | Begin selection | `packages/tmux/.tmux.conf` |

--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ Some tools require a one-time manual step after `install.sh`:
   - Claude Code statusline renders as two rows so long directory and branch names do not hide model/context/cost/elapsed details
   - row 1 shows directory, branch, dirty/ahead/behind, and (when present) the PR number colored by review state; row 2 shows model, the context gauge with token usage (`used/size`, falling back to a percentage), cost, and elapsed time
   - the statusline uses Nerd Font icons (folder/branch/model/clock/PR); these need the Hack Nerd Font (in `Brewfile`) and the `Hack Nerd Font Mono` fallback configured in `packages/wezterm/.config/wezterm/wezterm.lua` (git dirty/ahead/behind use plain `*`/`⇡`/`⇣` symbols)
-  - the statusline command also records Claude's actual worktree directory as tmux pane option `@preferred_cwd`; this is intentionally tiny, idempotent, and ignored on failure
-  - tmux bindings for shell/lazygit popup, pane splits, and new windows use `@preferred_cwd` when valid and fall back to `pane_current_path`
-  - `prefix + G` opens `lazygit` in a bottom pane from the preferred cwd
+  - Claude hooks record the latest session cwd under `$TMPDIR/claude-cwd-state`; tmux bindings use the latest matching Claude cwd for `claude agents` panes
+  - tmux bindings for shell/lazygit popup, pane splits, and new windows otherwise fall back to `pane_current_path`
+  - `prefix + G` opens `lazygit` in a bottom pane from the Claude-aware cwd
 - If `brew bundle` or `mise install` fails mid-run, fix the cause then rerun `dotfiles install`.
 
 ## Repository Structure
@@ -122,8 +122,9 @@ Each package contains dotfiles in their expected directory structure. The instal
 - **install.sh** - Main installation script with custom symlinking logic
 - **scripts/** - repository maintenance scripts (install/check/update helpers such as `check-updates.sh`, `lib/ui.sh`)
 - **packages/bin/.local/bin/dotfiles** - small launcher for install/check/help commands
-- **packages/bin/.local/bin/tmux-open** - tmux helper for opening popups, panes, and windows from a pane's preferred cwd
-- **packages/claude/.claude/statusline-command.sh** - Claude Code two-row statusline and tmux preferred cwd sync
+- **packages/bin/.local/bin/tmux-open** - tmux helper for opening popups, panes, and windows from a Claude-aware cwd
+- **packages/claude/.claude/statusline-command.sh** - Claude Code two-row statusline
+- **packages/claude/.claude/hooks/record-cwd-state.sh** - Claude Code hook that records session cwd state for `tmux-open`
 - **packages/bin/.local/bin/** - user-facing CLI helpers; prefer this location for agent/task utilities instead of `scripts/`
 - **packages/** - Individual application configurations
 - **KEYBINDINGS.md** - cheat sheet for custom macOS/terminal/Neovim keybindings

--- a/packages/bin/.local/bin/tmux-open
+++ b/packages/bin/.local/bin/tmux-open
@@ -9,8 +9,8 @@ Usage:
 
 Opens tmux UI from a pane-aware working directory.
 
-If the target pane has a valid @preferred_cwd pane option, tmux-open uses it.
-Otherwise it falls back to the pane's current path.
+For Claude agent panes, tmux-open first tries the most recent matching Claude
+cwd state. Otherwise it falls back to the pane's current path.
 EOF
 }
 
@@ -23,13 +23,6 @@ require_cmd() {
     command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
 }
 
-pane_option() {
-    local pane_id="$1"
-    local option="$2"
-
-    tmux show-options -p -v -t "$pane_id" "$option" 2>/dev/null || true
-}
-
 pane_format() {
     local pane_id="$1"
     local format="$2"
@@ -37,45 +30,101 @@ pane_format() {
     tmux display-message -p -t "$pane_id" "$format" 2>/dev/null || true
 }
 
-is_fresh_preferred_cwd() {
-    local updated_at="$1"
-    local max_age="${TMUX_OPEN_MAX_AGE_SECONDS:-86400}"
-    local now
-    local age
+state_dir() {
+    local tmpdir="${TMPDIR:-/tmp}"
 
-    [[ -n "$updated_at" ]] || return 0
-    [[ "$updated_at" =~ ^[0-9]+$ ]] || return 1
-    [[ "$max_age" =~ ^[0-9]+$ ]] || max_age="86400"
-    (( max_age <= 0 )) && return 0
+    printf '%s/claude-cwd-state\n' "${tmpdir%/}"
+}
 
-    now="$(date +%s)"
-    age=$((now - updated_at))
-    (( age <= max_age ))
+file_mtime() {
+    local file="$1"
+
+    stat -f '%m' "$file" 2>/dev/null || stat -c '%Y' "$file" 2>/dev/null || printf '0\n'
+}
+
+path_related() {
+    local left="$1"
+    local right="$2"
+
+    [[ -n "$left" && -n "$right" ]] || return 1
+    [[ "$left" == "$right" || "$left" == "$right"/* || "$right" == "$left"/* ]]
+}
+
+pane_has_claude_agents() {
+    local pane_id="$1"
+    local pane_tty
+    local tty_name
+
+    pane_tty="$(pane_format "$pane_id" "#{pane_tty}")"
+    [[ -n "$pane_tty" ]] || return 1
+
+    tty_name="${pane_tty#/dev/}"
+    ps -o command= -t "$tty_name" 2>/dev/null |
+        grep -E '(^|/)claude([[:space:]].*)?[[:space:]]agents([[:space:]]|$)' >/dev/null 2>&1 ||
+        return 1
+}
+
+latest_claude_cwd() {
+    local pane_current_path="$1"
+    local dir
+    local file
+    local cwd
+    local project_dir
+    local mtime
+    local best_mtime=0
+    local best_cwd=""
+    local us
+
+    command -v jq >/dev/null 2>&1 || return 1
+
+    dir="$(state_dir)"
+    [[ -d "$dir" && -n "$pane_current_path" ]] || return 1
+
+    us=$(printf '\037')
+    for file in "$dir"/session-*.json; do
+        [[ -f "$file" ]] || continue
+
+        IFS="$us" read -r cwd project_dir <<EOF
+$(jq -r '
+[
+    (.effective_cwd // ""),
+    (.project_dir // "")
+] | map(tostring) | join("\u001f")
+' "$file" 2>/dev/null || true)
+EOF
+
+        [[ -n "$cwd" && -d "$cwd" ]] || continue
+        if [[ -n "$project_dir" ]]; then
+            path_related "$pane_current_path" "$project_dir" || continue
+        else
+            path_related "$pane_current_path" "$cwd" || continue
+        fi
+
+        mtime="$(file_mtime "$file")"
+        [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+        if (( mtime >= best_mtime )); then
+            best_mtime="$mtime"
+            best_cwd="$cwd"
+        fi
+    done
+
+    [[ -n "$best_cwd" ]] || return 1
+    printf '%s\n' "$best_cwd"
 }
 
 resolved_cwd() {
     local pane_id="$1"
-    local preferred_cwd
-    local owner
-    local current_command
-    local updated_at
     local pane_current_path
+    local claude_cwd
 
-    preferred_cwd="$(pane_option "$pane_id" "@preferred_cwd")"
-    if [[ -n "$preferred_cwd" && -d "$preferred_cwd" ]]; then
-        owner="$(pane_option "$pane_id" "@preferred_cwd_owner")"
-        current_command="$(pane_format "$pane_id" "#{pane_current_command}")"
-        updated_at="$(pane_option "$pane_id" "@preferred_cwd_updated_at")"
-
-        if [[ -z "$owner" || -z "$current_command" || "$owner" == "$current_command" ]]; then
-            if is_fresh_preferred_cwd "$updated_at"; then
-                printf '%s\n' "$preferred_cwd"
-                return 0
-            fi
+    pane_current_path="$(pane_format "$pane_id" "#{pane_current_path}")"
+    if pane_has_claude_agents "$pane_id"; then
+        if claude_cwd="$(latest_claude_cwd "$pane_current_path")" && [[ -n "$claude_cwd" && -d "$claude_cwd" ]]; then
+            printf '%s\n' "$claude_cwd"
+            return 0
         fi
     fi
 
-    pane_current_path="$(pane_format "$pane_id" "#{pane_current_path}")"
     if [[ -n "$pane_current_path" && -d "$pane_current_path" ]]; then
         printf '%s\n' "$pane_current_path"
         return 0

--- a/packages/claude/.claude/hooks/record-cwd-state.sh
+++ b/packages/claude/.claude/hooks/record-cwd-state.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Record Claude Code session cwd state for tmux helpers.
+# Keep stdout empty so the hook never injects context or decisions.
+
+set -u
+
+input=$(cat)
+tmpdir="${TMPDIR:-/tmp}"
+state_dir="${tmpdir%/}/claude-cwd-state"
+
+mkdir -p "$state_dir" 2>/dev/null || exit 0
+
+record=$(
+    printf '%s' "$input" | jq -c \
+        --arg timestamp "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        --arg claude_project_dir "${CLAUDE_PROJECT_DIR:-}" \
+        '{
+            timestamp: $timestamp,
+            hook_event_name: (.hook_event_name // "" | tostring),
+            session_id: (.session_id // "" | tostring),
+            project_dir: $claude_project_dir,
+            worktree_path: (.worktree.path // "" | tostring),
+            workspace_current_dir: (.workspace.current_dir // "" | tostring),
+            cwd: (.cwd // "" | tostring),
+            old_cwd: (.old_cwd // "" | tostring),
+            new_cwd: (.new_cwd // "" | tostring),
+            effective_cwd: (.worktree.path // .workspace.current_dir // .new_cwd // .cwd // "" | tostring)
+        }' 2>/dev/null
+) || exit 0
+
+[ -n "$record" ] || exit 0
+
+session_id=$(printf '%s' "$record" | jq -r '.session_id // ""' 2>/dev/null)
+if [ -z "$session_id" ]; then
+    session_id="unknown"
+fi
+
+safe_session_id=$(printf '%s' "$session_id" | tr -cs '[:alnum:]_.-' '_')
+
+printf '%s\n' "$record" > "$state_dir/session-${safe_session_id}.json" 2>/dev/null || true
+
+exit 0

--- a/packages/claude/.claude/settings.json
+++ b/packages/claude/.claude/settings.json
@@ -31,9 +31,41 @@
       "Bash(rm -rf .git)"
     ]
   },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/record-cwd-state.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/record-cwd-state.sh"
+          }
+        ]
+      }
+    ],
+    "CwdChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/record-cwd-state.sh"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
-    "command": "bash ~/.claude/statusline-command.sh"
+    "command": "~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
     "code-review@claude-plugins-official": true,

--- a/packages/claude/.claude/statusline-command.sh
+++ b/packages/claude/.claude/statusline-command.sh
@@ -9,28 +9,6 @@
 # icons carry the meaning.
 
 # --- Helpers ------------------------------------------------------------------
-sync_tmux_preferred_cwd() {
-    local preferred_cwd="$1"
-    # Claude Code does not pass the standard TMUX_PANE to the statusLine command,
-    # but it does export CLAUDE_TMUX_PANE with the owning pane id (and it survives
-    # into agent view / child sessions). Prefer the standard var if ever present.
-    local pane="${TMUX_PANE:-${CLAUDE_TMUX_PANE:-}}"
-    local pane_command
-
-    # The statusLine is meant for display, but it is the only Claude callback that
-    # reliably knows its tmux pane, so we (idempotently, briefly, ignoring every
-    # failure) cache the active worktree cwd on the pane for tmux-open to read.
-    if [ -z "$pane" ] || [ -z "$preferred_cwd" ] || [ ! -d "$preferred_cwd" ]; then
-        return 0
-    fi
-    command -v tmux >/dev/null 2>&1 || return 0
-
-    pane_command="$(tmux display-message -p -t "$pane" '#{pane_current_command}' 2>/dev/null || true)"
-    tmux set-option -p -t "$pane" @preferred_cwd "$preferred_cwd" >/dev/null 2>&1 || true
-    tmux set-option -p -t "$pane" @preferred_cwd_owner "$pane_command" >/dev/null 2>&1 || true
-    tmux set-option -p -t "$pane" @preferred_cwd_updated_at "$(date +%s)" >/dev/null 2>&1 || true
-}
-
 text_len() {
     local LC_ALL=C
     printf '%s' "${#1}"
@@ -134,8 +112,11 @@ input=$(cat)
 # (tab is IFS whitespace), which would misalign every field after a missing one.
 us=$(printf '\037')
 IFS="$us" read -r cwd model used_pct cost_usd duration_ms input_tokens ctx_size pr_number pr_state <<EOF
-$(printf '%s' "$input" | jq -r '[
-    .worktree.path // .workspace.current_dir // .cwd // "",
+$(printf '%s' "$input" | jq -r '
+def preferred_cwd:
+    .worktree.path // .workspace.current_dir // .cwd // "";
+[
+    preferred_cwd,
     .model.display_name // "",
     .context_window.used_percentage // "",
     .cost.total_cost_usd // "",
@@ -146,9 +127,6 @@ $(printf '%s' "$input" | jq -r '[
     .pr.review_state // ""
 ] | map(tostring) | join("\u001f")')
 EOF
-
-# Cache the worktree cwd on the tmux pane (see sync_tmux_preferred_cwd above).
-sync_tmux_preferred_cwd "$cwd"
 
 # --- Directory display ---------------------------------------------------------
 dir_display="$cwd"

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -9,7 +9,7 @@ bind-key C-a send-prefix
 # Automatic renumbering of pane and window numbers
 set-option -g renumber-windows on
 
-# Pane/window creation from the active pane's preferred current directory.
+# Pane/window creation from the active pane's Claude-aware current directory.
 bind | run-shell -b '~/.local/bin/tmux-open split-h "#{pane_id}"'
 bind - run-shell -b '~/.local/bin/tmux-open split-v "#{pane_id}"'
 
@@ -19,7 +19,7 @@ bind -r J resize-pane -D 5
 bind -r H resize-pane -L 5
 bind -r L resize-pane -R 5
 
-# Open shells and lazygit from the active pane's preferred current directory.
+# Open shells and lazygit from the active pane's Claude-aware current directory.
 bind t run-shell -b '~/.local/bin/tmux-open new-window "#{pane_id}"'
 bind u run-shell -b '~/.local/bin/tmux-open popup "#{pane_id}"'
 bind g run-shell -b '~/.local/bin/tmux-open popup-lazygit "#{pane_id}"'

--- a/tests/claude-cwd-state-hook.sh
+++ b/tests/claude-cwd-state-hook.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/ui.sh"
+
+HOOK="${REPO_ROOT}/packages/claude/.claude/hooks/record-cwd-state.sh"
+
+fail() {
+    warn "$*"
+    exit 1
+}
+
+test_records_minimal_worktree_state() {
+    local tmpdir
+    local project_dir
+    local cwd
+    local worktree_path
+    local output
+    local session_file
+
+    tmpdir="$(mktemp -d /tmp/claude-cwd-hook-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/claude-cwd-hook-project.XXXXXX)"
+    cwd="$(mktemp -d /tmp/claude-cwd-hook-cwd.XXXXXX)"
+    worktree_path="$(mktemp -d /tmp/claude-cwd-hook-worktree.XXXXXX)"
+
+    output="$(jq -n \
+        --arg cwd "$cwd" \
+        --arg worktree_path "$worktree_path" \
+        '{
+            hook_event_name: "UserPromptSubmit",
+            session_id: "session-worktree",
+            cwd: $cwd,
+            worktree: { path: $worktree_path },
+            transcript_path: "/tmp/ignored.jsonl",
+            permission_mode: "default"
+        }' |
+        TMPDIR="$tmpdir" CLAUDE_PROJECT_DIR="$project_dir" bash "$HOOK")"
+
+    [[ -z "$output" ]] || fail "expected hook stdout to stay empty"
+
+    session_file="${tmpdir%/}/claude-cwd-state/session-session-worktree.json"
+    [[ -f "$session_file" ]] || fail "expected session state to be written"
+    [[ ! -f "${tmpdir%/}/claude-cwd-state/latest.json" ]] || fail "expected hook not to write latest.json"
+    [[ ! -f "${tmpdir%/}/claude-cwd-state/events.jsonl" ]] || fail "expected hook not to append events.jsonl"
+
+    jq -e \
+        --arg project_dir "$project_dir" \
+        --arg cwd "$cwd" \
+        --arg worktree_path "$worktree_path" \
+        '
+            .project_dir == $project_dir
+            and .cwd == $cwd
+            and .worktree_path == $worktree_path
+            and .effective_cwd == $worktree_path
+            and (has("transcript_path") | not)
+            and (has("env") | not)
+        ' "$session_file" >/dev/null ||
+        fail "expected minimal state with worktree cwd priority"
+
+    rm -rf "$tmpdir" "$project_dir" "$cwd" "$worktree_path"
+}
+
+test_records_cwd_changed_state() {
+    local tmpdir
+    local project_dir
+    local old_cwd
+    local new_cwd
+    local session_file
+
+    tmpdir="$(mktemp -d /tmp/claude-cwd-hook-cwdchanged-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/claude-cwd-hook-cwdchanged-project.XXXXXX)"
+    old_cwd="$(mktemp -d /tmp/claude-cwd-hook-old.XXXXXX)"
+    new_cwd="$(mktemp -d /tmp/claude-cwd-hook-new.XXXXXX)"
+
+    jq -n \
+        --arg old_cwd "$old_cwd" \
+        --arg new_cwd "$new_cwd" \
+        '{
+            hook_event_name: "CwdChanged",
+            session_id: "session-cwdchanged",
+            cwd: $old_cwd,
+            old_cwd: $old_cwd,
+            new_cwd: $new_cwd
+        }' |
+        TMPDIR="$tmpdir" CLAUDE_PROJECT_DIR="$project_dir" bash "$HOOK" >/dev/null
+
+    session_file="${tmpdir%/}/claude-cwd-state/session-session-cwdchanged.json"
+    jq -e \
+        --arg new_cwd "$new_cwd" \
+        '.hook_event_name == "CwdChanged" and .effective_cwd == $new_cwd' "$session_file" >/dev/null ||
+        fail "expected CwdChanged state to use new_cwd"
+
+    rm -rf "$tmpdir" "$project_dir" "$old_cwd" "$new_cwd"
+}
+
+main() {
+    step "Running Claude cwd state hook tests"
+    test_records_minimal_worktree_state
+    ok "records minimal worktree state"
+    test_records_cwd_changed_state
+    ok "records CwdChanged state"
+}
+
+main "$@"

--- a/tests/claude-statusline.sh
+++ b/tests/claude-statusline.sh
@@ -52,42 +52,6 @@ mock_input() {
         }'
 }
 
-write_tmux_wrapper() {
-    local wrapper_path="$1"
-    local tmux_log="$2"
-
-    cat >"$wrapper_path" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-
-cmd="\${1:-}"
-shift || true
-printf '%s' "\$cmd" >>"${tmux_log}"
-for arg in "\$@"; do
-    printf ' %s' "\$arg" >>"${tmux_log}"
-done
-printf '\n' >>"${tmux_log}"
-
-case "\$cmd" in
-    display-message)
-        if [[ "\$*" == *"#{pane_current_command}"* ]]; then
-            printf 'claude\n'
-            exit 0
-        fi
-        exit 1
-        ;;
-    set-option)
-        exit 0
-        ;;
-    *)
-        printf 'unexpected tmux command: %s\n' "\$cmd" >&2
-        exit 1
-        ;;
-esac
-EOF
-    chmod +x "$wrapper_path"
-}
-
 test_statusline_outputs_two_fitted_lines() {
     local repo_root
     local branch
@@ -116,41 +80,12 @@ test_statusline_outputs_two_fitted_lines() {
     rm -rf "$(dirname "$(dirname "$(dirname "$repo_root")")")"
 }
 
-test_statusline_sets_preferred_cwd_in_tmux() {
-    local cwd
-    local worktree_path
-    local wrapper_dir
-    local tmux_log
-    local output
-
-    cwd="$(mktemp -d /tmp/claude-statusline-cwd.XXXXXX)"
-    worktree_path="$(mktemp -d /tmp/claude-statusline-worktree.XXXXXX)"
-    wrapper_dir="$(mktemp -d /tmp/claude-statusline-tmux-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/claude-statusline-tmux-log.XXXXXX)"
-
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
-
-    output="$(mock_input "$cwd" "$worktree_path" |
-        TMUX_PANE="%7" PATH="${wrapper_dir}:$PATH" COLUMNS=80 bash "$STATUSLINE")"
-
-    [[ -n "$output" ]] || fail "expected statusline to keep rendering while syncing tmux cwd"
-    grep -F "set-option -p -t %7 @preferred_cwd ${worktree_path}" "$tmux_log" >/dev/null ||
-        fail "expected statusline to save worktree path as preferred cwd"
-    grep -F "set-option -p -t %7 @preferred_cwd_owner claude" "$tmux_log" >/dev/null ||
-        fail "expected statusline to save pane command as preferred cwd owner"
-    grep -F "set-option -p -t %7 @preferred_cwd_updated_at" "$tmux_log" >/dev/null ||
-        fail "expected statusline to save preferred cwd timestamp"
-
-    rm -rf "$cwd" "$worktree_path" "$wrapper_dir" "$tmux_log"
-}
-
 test_statusline_works_outside_tmux() {
     local cwd
     local output
     local visible
 
     cwd="$(mktemp -d /tmp/claude-statusline-outside.XXXXXX)"
-    # Drop both pane hints so the sync truly no-ops (and never touches a real pane).
     output="$(mock_input "$cwd" | env -u TMUX_PANE -u CLAUDE_TMUX_PANE COLUMNS=80 bash "$STATUSLINE")"
     visible="$(printf '%s' "$output" | strip_ansi)"
 
@@ -160,27 +95,48 @@ test_statusline_works_outside_tmux() {
     rm -rf "$cwd"
 }
 
-test_statusline_uses_claude_tmux_pane_when_tmux_pane_absent() {
+test_statusline_prefers_worktree_path() {
     local cwd
+    local worktree_parent
     local worktree_path
+    local visible
+
+    cwd="$(mktemp -d /tmp/claude-statusline-cwd.XXXXXX)"
+    worktree_parent="$(mktemp -d /tmp/claude-statusline-worktree-parent.XXXXXX)"
+    worktree_path="${worktree_parent}/agent-worktree"
+    mkdir -p "$worktree_path"
+
+    visible="$(mock_input "$cwd" "$worktree_path" | COLUMNS=120 bash "$STATUSLINE" | strip_ansi)"
+
+    [[ "$visible" == *"agent-worktree"* ]] ||
+        fail "expected statusline to prefer worktree path, got: $visible"
+
+    rm -rf "$cwd" "$worktree_parent"
+}
+
+test_statusline_does_not_call_tmux() {
+    local cwd
     local wrapper_dir
-    local tmux_log
+    local output
+    local visible
 
-    cwd="$(mktemp -d /tmp/claude-statusline-cpane-cwd.XXXXXX)"
-    worktree_path="$(mktemp -d /tmp/claude-statusline-cpane-wt.XXXXXX)"
-    wrapper_dir="$(mktemp -d /tmp/claude-statusline-cpane-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/claude-statusline-cpane-log.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    cwd="$(mktemp -d /tmp/claude-statusline-no-tmux.XXXXXX)"
+    wrapper_dir="$(mktemp -d /tmp/claude-statusline-no-tmux-wrapper.XXXXXX)"
+    cat >"${wrapper_dir}/tmux" <<'EOF'
+#!/usr/bin/env bash
+printf 'statusline must not call tmux\n' >&2
+exit 99
+EOF
+    chmod +x "${wrapper_dir}/tmux"
 
-    # Claude Code does not pass TMUX_PANE but exports CLAUDE_TMUX_PANE; the sync
-    # must fall back to it (agent view / child sessions).
-    mock_input "$cwd" "$worktree_path" |
-        env -u TMUX_PANE CLAUDE_TMUX_PANE="%9" PATH="${wrapper_dir}:$PATH" COLUMNS=80 bash "$STATUSLINE" >/dev/null
+    output="$(mock_input "$cwd" |
+        TMUX_PANE="%7" CLAUDE_TMUX_PANE="%9" PATH="${wrapper_dir}:$PATH" COLUMNS=80 bash "$STATUSLINE")"
+    visible="$(printf '%s' "$output" | strip_ansi)"
 
-    grep -F "set-option -p -t %9 @preferred_cwd ${worktree_path}" "$tmux_log" >/dev/null ||
-        fail "expected statusline to use CLAUDE_TMUX_PANE when TMUX_PANE is absent"
+    [[ "$(printf '%s\n' "$visible" | visible_line_count)" == "2" ]] ||
+        fail "expected statusline to render while tmux is unavailable"
 
-    rm -rf "$cwd" "$worktree_path" "$wrapper_dir" "$tmux_log"
+    rm -rf "$cwd" "$wrapper_dir"
 }
 
 test_statusline_shows_context_tokens() {
@@ -262,12 +218,12 @@ main() {
     step "Running Claude statusline tests"
     test_statusline_outputs_two_fitted_lines
     ok "statusline renders two fitted rows"
-    test_statusline_sets_preferred_cwd_in_tmux
-    ok "statusline records preferred cwd in tmux"
     test_statusline_works_outside_tmux
     ok "statusline works outside tmux"
-    test_statusline_uses_claude_tmux_pane_when_tmux_pane_absent
-    ok "statusline uses CLAUDE_TMUX_PANE when TMUX_PANE is absent"
+    test_statusline_prefers_worktree_path
+    ok "statusline prefers worktree path"
+    test_statusline_does_not_call_tmux
+    ok "statusline does not call tmux"
     test_statusline_shows_context_tokens
     ok "statusline shows context tokens when available"
     test_statusline_shows_tokens_without_percentage

--- a/tests/tmux-open.sh
+++ b/tests/tmux-open.sh
@@ -32,23 +32,9 @@ done
 printf '\n' >>"${tmux_log}"
 
 case "\$cmd" in
-    show-options)
-        option="\${!#}"
-        case "\$option" in
-            @preferred_cwd)
-                printf '%s\n' "\${TMUX_TEST_PREFERRED_CWD:-}"
-                ;;
-            @preferred_cwd_owner)
-                printf '%s\n' "\${TMUX_TEST_OWNER:-}"
-                ;;
-            @preferred_cwd_updated_at)
-                printf '%s\n' "\${TMUX_TEST_UPDATED_AT:-}"
-                ;;
-        esac
-        ;;
     display-message)
-        if [[ "\$*" == *"#{pane_current_command}"* ]]; then
-            printf '%s\n' "\${TMUX_TEST_CURRENT_COMMAND:-zsh}"
+        if [[ "\$*" == *"#{pane_tty}"* ]]; then
+            printf '%s\n' "\${TMUX_TEST_PANE_TTY:-/dev/ttys999}"
             exit 0
         fi
         if [[ "\$*" == *"#{pane_current_path}"* ]]; then
@@ -73,6 +59,49 @@ EOF
     chmod +x "$wrapper_path"
 }
 
+write_ps_wrapper() {
+    local wrapper_path="$1"
+
+    cat >"$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"-o command="* && "$*" == *"-t ttys999"* ]]; then
+    printf '%s\n' "${TMUX_TEST_PS_COMMANDS:-zsh}"
+    exit 0
+fi
+
+exit 1
+EOF
+    chmod +x "$wrapper_path"
+}
+
+write_claude_state() {
+    local tmpdir="$1"
+    local session_id="$2"
+    local cwd="$3"
+    local project_dir="$4"
+    local touch_time="$5"
+    local state_dir
+    local state_file
+
+    state_dir="${tmpdir%/}/claude-cwd-state"
+    state_file="${state_dir}/session-${session_id}.json"
+    mkdir -p "$state_dir"
+
+    jq -n \
+        --arg session_id "$session_id" \
+        --arg project_dir "$project_dir" \
+        --arg cwd "$cwd" \
+        '{
+            session_id: $session_id,
+            project_dir: $project_dir,
+            effective_cwd: $cwd
+        }' >"$state_file"
+
+    touch -t "$touch_time" "$state_file"
+}
+
 run_tmux_open() {
     local wrapper_dir="$1"
     shift
@@ -80,141 +109,167 @@ run_tmux_open() {
     PATH="${wrapper_dir}:$PATH" "$TMUX_OPEN" "$@"
 }
 
-test_uses_valid_preferred_cwd_for_popup() {
+setup_wrappers() {
+    local wrapper_dir="$1"
+    local tmux_log="$2"
+
+    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    write_ps_wrapper "${wrapper_dir}/ps"
+}
+
+test_uses_latest_matching_claude_cwd_for_popup() {
     local wrapper_dir
     local tmux_log
-    local preferred_cwd
+    local tmpdir
+    local project_dir
+    local other_project_dir
+    local old_cwd
+    local expected_cwd
+    local other_cwd
     local fallback_cwd
 
     wrapper_dir="$(mktemp -d /tmp/tmux-open-wrapper.XXXXXX)"
     tmux_log="$(mktemp /tmp/tmux-open-log.XXXXXX)"
-    preferred_cwd="$(mktemp -d /tmp/tmux-open-preferred.XXXXXX)"
-    fallback_cwd="$(mktemp -d /tmp/tmux-open-fallback.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    tmpdir="$(mktemp -d /tmp/tmux-open-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/tmux-open-project.XXXXXX)"
+    other_project_dir="$(mktemp -d /tmp/tmux-open-other-project.XXXXXX)"
+    old_cwd="$(mktemp -d /tmp/tmux-open-old-cwd.XXXXXX)"
+    expected_cwd="$(mktemp -d /tmp/tmux-open-expected-cwd.XXXXXX)"
+    other_cwd="$(mktemp -d /tmp/tmux-open-other-cwd.XXXXXX)"
+    fallback_cwd="$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log"
 
-    TMUX_TEST_PREFERRED_CWD="$preferred_cwd" \
-        TMUX_TEST_OWNER="claude" \
-        TMUX_TEST_CURRENT_COMMAND="claude" \
+    write_claude_state "$tmpdir" old "$old_cwd" "$project_dir" 202401010000.00
+    write_claude_state "$tmpdir" expected "$expected_cwd" "$project_dir" 202401010001.00
+    write_claude_state "$tmpdir" other "$other_cwd" "$other_project_dir" 202401010002.00
+
+    TMPDIR="$tmpdir" \
+        TMUX_TEST_PS_COMMANDS="claude agents" \
         TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
         run_tmux_open "$wrapper_dir" popup-lazygit "%1"
 
-    grep -F "display-popup -t %1 -d ${preferred_cwd} -xC -yC -w 85% -h 85% -E lazygit" "$tmux_log" >/dev/null ||
-        fail "expected popup-lazygit to use preferred cwd"
+    grep -F "display-popup -t %1 -d ${expected_cwd} -xC -yC -w 85% -h 85% -E lazygit" "$tmux_log" >/dev/null ||
+        fail "expected popup-lazygit to use latest matching Claude cwd"
 
-    rm -rf "$wrapper_dir" "$tmux_log" "$preferred_cwd" "$fallback_cwd"
+    rm -rf "$wrapper_dir" "$tmux_log" "$tmpdir" "$project_dir" "$other_project_dir" "$old_cwd" "$expected_cwd" "$other_cwd"
 }
 
-test_falls_back_when_preferred_cwd_is_missing() {
+test_non_claude_pane_uses_pane_current_path() {
     local wrapper_dir
     local tmux_log
-    local missing_cwd
+    local tmpdir
+    local project_dir
+    local claude_cwd
     local fallback_cwd
 
-    wrapper_dir="$(mktemp -d /tmp/tmux-open-missing-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/tmux-open-missing-log.XXXXXX)"
-    missing_cwd="/tmp/tmux-open-missing-not-created"
-    fallback_cwd="$(mktemp -d /tmp/tmux-open-missing-fallback.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    wrapper_dir="$(mktemp -d /tmp/tmux-open-non-claude-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-open-non-claude-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-open-non-claude-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/tmux-open-non-claude-project.XXXXXX)"
+    claude_cwd="$(mktemp -d /tmp/tmux-open-non-claude-cwd.XXXXXX)"
+    fallback_cwd="$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log"
+    write_claude_state "$tmpdir" ignored "$claude_cwd" "$project_dir" 202401010000.00
 
-    TMUX_TEST_PREFERRED_CWD="$missing_cwd" \
-        TMUX_TEST_OWNER="claude" \
-        TMUX_TEST_CURRENT_COMMAND="claude" \
+    TMPDIR="$tmpdir" \
+        TMUX_TEST_PS_COMMANDS="zsh" \
         TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
         run_tmux_open "$wrapper_dir" split-h "%1"
 
     grep -F "split-window -h -t %1 -c ${fallback_cwd}" "$tmux_log" >/dev/null ||
-        fail "expected split-h to fall back to pane_current_path"
+        fail "expected split-h to ignore Claude cwd outside claude agents panes"
 
-    rm -rf "$wrapper_dir" "$tmux_log" "$fallback_cwd"
+    rm -rf "$wrapper_dir" "$tmux_log" "$tmpdir" "$project_dir" "$claude_cwd"
 }
 
-test_falls_back_when_owner_mismatches() {
+test_claude_pane_falls_back_when_state_is_missing() {
     local wrapper_dir
     local tmux_log
-    local preferred_cwd
+    local tmpdir
     local fallback_cwd
 
-    wrapper_dir="$(mktemp -d /tmp/tmux-open-owner-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/tmux-open-owner-log.XXXXXX)"
-    preferred_cwd="$(mktemp -d /tmp/tmux-open-owner-preferred.XXXXXX)"
-    fallback_cwd="$(mktemp -d /tmp/tmux-open-owner-fallback.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    wrapper_dir="$(mktemp -d /tmp/tmux-open-missing-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-open-missing-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-open-missing-state.XXXXXX)"
+    fallback_cwd="$(mktemp -d /tmp/tmux-open-missing-fallback.XXXXXX)"
+    setup_wrappers "$wrapper_dir" "$tmux_log"
 
-    TMUX_TEST_PREFERRED_CWD="$preferred_cwd" \
-        TMUX_TEST_OWNER="claude" \
-        TMUX_TEST_CURRENT_COMMAND="zsh" \
-        TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
-        TMUX_TEST_SESSION_ID="\$9" \
-        run_tmux_open "$wrapper_dir" new-window "%1"
-
-    grep -F "new-window -t \$9 -c ${fallback_cwd}" "$tmux_log" >/dev/null ||
-        fail "expected new-window to fall back on owner mismatch"
-
-    rm -rf "$wrapper_dir" "$tmux_log" "$preferred_cwd" "$fallback_cwd"
-}
-
-test_falls_back_when_preferred_cwd_is_stale() {
-    local wrapper_dir
-    local tmux_log
-    local preferred_cwd
-    local fallback_cwd
-
-    wrapper_dir="$(mktemp -d /tmp/tmux-open-stale-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/tmux-open-stale-log.XXXXXX)"
-    preferred_cwd="$(mktemp -d /tmp/tmux-open-stale-preferred.XXXXXX)"
-    fallback_cwd="$(mktemp -d /tmp/tmux-open-stale-fallback.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
-
-    TMUX_TEST_PREFERRED_CWD="$preferred_cwd" \
-        TMUX_TEST_OWNER="claude" \
-        TMUX_TEST_CURRENT_COMMAND="claude" \
-        TMUX_TEST_UPDATED_AT="1" \
-        TMUX_OPEN_MAX_AGE_SECONDS="1" \
+    TMPDIR="$tmpdir" \
+        TMUX_TEST_PS_COMMANDS="claude agents" \
         TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
         run_tmux_open "$wrapper_dir" split-v "%1"
 
     grep -F "split-window -v -t %1 -c ${fallback_cwd}" "$tmux_log" >/dev/null ||
-        fail "expected split-v to fall back on stale preferred cwd"
+        fail "expected split-v to fall back when Claude state is missing"
 
-    rm -rf "$wrapper_dir" "$tmux_log" "$preferred_cwd" "$fallback_cwd"
+    rm -rf "$wrapper_dir" "$tmux_log" "$tmpdir" "$fallback_cwd"
 }
 
-test_opens_lazygit_in_bottom_pane() {
+test_split_v_lazygit_uses_claude_cwd() {
     local wrapper_dir
     local tmux_log
-    local preferred_cwd
-    local fallback_cwd
+    local tmpdir
+    local project_dir
+    local claude_cwd
 
-    wrapper_dir="$(mktemp -d /tmp/tmux-open-lazygit-pane-wrapper.XXXXXX)"
-    tmux_log="$(mktemp /tmp/tmux-open-lazygit-pane-log.XXXXXX)"
-    preferred_cwd="$(mktemp -d /tmp/tmux-open-lazygit-pane-preferred.XXXXXX)"
-    fallback_cwd="$(mktemp -d /tmp/tmux-open-lazygit-pane-fallback.XXXXXX)"
-    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+    wrapper_dir="$(mktemp -d /tmp/tmux-open-split-v-lazygit-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-open-split-v-lazygit-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-open-split-v-lazygit-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/tmux-open-split-v-lazygit-project.XXXXXX)"
+    claude_cwd="$(mktemp -d /tmp/tmux-open-split-v-lazygit-cwd.XXXXXX)"
+    setup_wrappers "$wrapper_dir" "$tmux_log"
+    write_claude_state "$tmpdir" agent "$claude_cwd" "$project_dir" 202401010000.00
 
-    TMUX_TEST_PREFERRED_CWD="$preferred_cwd" \
-        TMUX_TEST_OWNER="claude" \
-        TMUX_TEST_CURRENT_COMMAND="claude" \
-        TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
+    TMPDIR="$tmpdir" \
+        TMUX_TEST_PS_COMMANDS="claude agents" \
+        TMUX_TEST_PANE_CURRENT_PATH="$project_dir" \
         run_tmux_open "$wrapper_dir" split-v-lazygit "%1"
 
-    grep -F "split-window -v -t %1 -c ${preferred_cwd} lazygit" "$tmux_log" >/dev/null ||
-        fail "expected split-v-lazygit to open lazygit below from preferred cwd"
+    grep -F "split-window -v -t %1 -c ${claude_cwd} lazygit" "$tmux_log" >/dev/null ||
+        fail "expected split-v-lazygit to use Claude cwd and launch lazygit"
 
-    rm -rf "$wrapper_dir" "$tmux_log" "$preferred_cwd" "$fallback_cwd"
+    rm -rf "$wrapper_dir" "$tmux_log" "$tmpdir" "$project_dir" "$claude_cwd"
+}
+
+test_new_window_uses_claude_cwd_and_session_id() {
+    local wrapper_dir
+    local tmux_log
+    local tmpdir
+    local project_dir
+    local claude_cwd
+
+    wrapper_dir="$(mktemp -d /tmp/tmux-open-new-window-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-open-new-window-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-open-new-window-state.XXXXXX)"
+    project_dir="$(mktemp -d /tmp/tmux-open-new-window-project.XXXXXX)"
+    claude_cwd="$(mktemp -d /tmp/tmux-open-new-window-cwd.XXXXXX)"
+    setup_wrappers "$wrapper_dir" "$tmux_log"
+    write_claude_state "$tmpdir" agent "$claude_cwd" "$project_dir" 202401010000.00
+
+    TMPDIR="$tmpdir" \
+        TMUX_TEST_PS_COMMANDS="claude agents" \
+        TMUX_TEST_PANE_CURRENT_PATH="$project_dir" \
+        TMUX_TEST_SESSION_ID="\$9" \
+        run_tmux_open "$wrapper_dir" new-window "%1"
+
+    grep -F "new-window -t \$9 -c ${claude_cwd}" "$tmux_log" >/dev/null ||
+        fail "expected new-window to use Claude cwd and session id"
+
+    rm -rf "$wrapper_dir" "$tmux_log" "$tmpdir" "$project_dir" "$claude_cwd"
 }
 
 main() {
     step "Running tmux-open tests"
-    test_uses_valid_preferred_cwd_for_popup
-    ok "uses valid preferred cwd for lazygit popup"
-    test_falls_back_when_preferred_cwd_is_missing
-    ok "falls back when preferred cwd is missing"
-    test_falls_back_when_owner_mismatches
-    ok "falls back when owner mismatches"
-    test_falls_back_when_preferred_cwd_is_stale
-    ok "falls back when preferred cwd is stale"
-    test_opens_lazygit_in_bottom_pane
-    ok "opens lazygit in a bottom pane"
+    test_uses_latest_matching_claude_cwd_for_popup
+    ok "uses latest matching Claude cwd for lazygit popup"
+    test_non_claude_pane_uses_pane_current_path
+    ok "uses pane_current_path outside claude agents panes"
+    test_claude_pane_falls_back_when_state_is_missing
+    ok "falls back when Claude state is missing"
+    test_split_v_lazygit_uses_claude_cwd
+    ok "uses Claude cwd for split-v lazygit"
+    test_new_window_uses_claude_cwd_and_session_id
+    ok "opens new windows from Claude cwd"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Replaces the statusline-driven `@preferred_cwd` pane-option sync with Claude Code hooks that record each session's cwd under `$TMPDIR/claude-cwd-state`. `tmux-open` now resolves a `claude agents` pane's working directory from the latest matching state file, falling back to `pane_current_path` (then `$HOME`) otherwise.

This decouples cwd recording from the statusline (which is now display-only) and removes its dependency on being able to write tmux pane options.

## Changes

- **New hook** `packages/claude/.claude/hooks/record-cwd-state.sh`, wired into `SessionStart` / `UserPromptSubmit` / `CwdChanged`. It records paths/IDs only — never transcript content or env — and sanitizes `session_id` before using it in a filename.
- **Statusline** drops `sync_tmux_preferred_cwd`; it no longer mutates tmux state.
- **tmux-open** rewrites `resolved_cwd` to read `session-*.json` state for `claude agents` panes.
- **No `Stop` hook** and **no `latest.json`**: avoids finished sessions refreshing their mtime / writing output nothing consumes.
- Scripts are invoked directly (`chmod +x`, no `bash` prefix), matching Claude Code docs convention.
- Docs (`README.md`, `KEYBINDINGS.md`, `.tmux.conf` comments) updated to "Claude-aware cwd"; `settings.local.json` added to the global gitignore.

## Tests

- New `tests/claude-cwd-state-hook.sh`.
- `tests/tmux-open.sh` gains a `split-v-lazygit` regression test (`prefix + G`).
- All suites pass: `bash tests/claude-cwd-state-hook.sh`, `bash tests/tmux-open.sh`, `bash tests/claude-statusline.sh`.

## Known tradeoff

For multiple `claude agents` panes in the same project, the latest-mtime heuristic may pick another pane's cwd. This is intentionally accepted as an acceptable experiential tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)