### PR TITLE
Improve tmux workflow

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -49,7 +49,6 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 | `Ctrl + p` | Prefix history search (previous) | `packages/zsh/.zshrc` |
 | `Ctrl + n` | Prefix history search (next) | `packages/zsh/.zshrc` |
 | `Ctrl + z` | `zoxide` interactive directory jump | `packages/zsh/.zshrc` |
-| `Ctrl + @` | `ghq` + `fzf` repo picker (`cdrepo`) | `packages/zsh/.zshrc` |
 
 ### tmux
 
@@ -60,12 +59,19 @@ Quick reference for custom shortcuts configured in this dotfiles repo.
 | `prefix + \|` | Split pane vertically (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + -` | Split pane horizontally (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + H/J/K/L` | Resize pane | `packages/tmux/.tmux.conf` |
-| `prefix + t` | New window (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + t` | New window (prompt for name) | `packages/tmux/.tmux.conf` |
+| `prefix + T` | New session (prompt for name) | `packages/tmux/.tmux.conf` |
+| `prefix + r` | Rename window | `packages/tmux/.tmux.conf` |
+| `prefix + R` | Rename session | `packages/tmux/.tmux.conf` |
+| `prefix + e` | Edit pane label | `packages/tmux/.tmux.conf` |
+| `prefix + E` | Clear pane label | `packages/tmux/.tmux.conf` |
 | `prefix + u` | Open a shell in a centered tmux popup (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + g` | Open `lazygit` in centered tmux popup (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
 | `prefix + G` | Open `lazygit` in a bottom pane (Claude-aware cwd) | `packages/tmux/.tmux.conf` |
+| `prefix + P` | Open project session picker (`ghq` + `fzf`) | `packages/tmux/.tmux.conf` |
 | `prefix + n/p` | Next/previous window | `packages/tmux/.tmux.conf` |
 | `prefix + s` | Open session chooser (`choose-tree`) | `packages/tmux/.tmux.conf` |
+| `prefix + {/}` | Swap pane up/down (tmux default) | tmux default |
 | `copy-mode` + `v` | Begin selection | `packages/tmux/.tmux.conf` |
 | `copy-mode` + `y` | Copy selection to macOS clipboard | `packages/tmux/.tmux.conf` |
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Some tools require a one-time manual step after `install.sh`:
   - row 1 shows directory, branch, dirty/ahead/behind, and (when present) the PR number colored by review state; row 2 shows model, the context gauge with token usage (`used/size`, falling back to a percentage), cost, and elapsed time
   - the statusline uses Nerd Font icons (folder/branch/model/clock/PR); these need the Hack Nerd Font (in `Brewfile`) and the `Hack Nerd Font Mono` fallback configured in `packages/wezterm/.config/wezterm/wezterm.lua` (git dirty/ahead/behind use plain `*`/`⇡`/`⇣` symbols)
   - Claude hooks record the latest session cwd under `$TMPDIR/claude-cwd-state`; tmux bindings use the latest matching Claude cwd for `claude agents` panes
-  - tmux bindings for shell/lazygit popup, pane splits, and new windows otherwise fall back to `pane_current_path`
+  - interactive zsh auto-starts a `home` tmux session with a `main` window, except in Claude/Codex/VS Code terminals
+  - tmux bindings for shell/lazygit popup and pane splits otherwise fall back to `pane_current_path`
+  - `prefix + t` and `prefix + T` prompt for stable window/session names
+  - `prefix + P` opens a `ghq` + `fzf` project picker that switches to an existing project session or creates one with a `main` window
   - `prefix + G` opens `lazygit` in a bottom pane from the Claude-aware cwd
 - If `brew bundle` or `mise install` fails mid-run, fix the cause then rerun `dotfiles install`.
 
@@ -123,6 +126,7 @@ Each package contains dotfiles in their expected directory structure. The instal
 - **scripts/** - repository maintenance scripts (install/check/update helpers such as `check-updates.sh`, `lib/ui.sh`)
 - **packages/bin/.local/bin/dotfiles** - small launcher for install/check/help commands
 - **packages/bin/.local/bin/tmux-open** - tmux helper for opening popups, panes, and windows from a Claude-aware cwd
+- **packages/bin/.local/bin/tmux-project** - tmux helper for opening project sessions from a `ghq` + `fzf` picker
 - **packages/claude/.claude/statusline-command.sh** - Claude Code two-row statusline
 - **packages/claude/.claude/hooks/record-cwd-state.sh** - Claude Code hook that records session cwd state for `tmux-open`
 - **packages/bin/.local/bin/** - user-facing CLI helpers; prefer this location for agent/task utilities instead of `scripts/`

--- a/packages/bin/.local/bin/tmux-project
+++ b/packages/bin/.local/bin/tmux-project
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  tmux-project
+
+Select a ghq repository with fzf, then switch to a tmux session for it.
+If the session does not exist, tmux-project creates it with a main window from
+the selected repository root.
+EOF
+}
+
+die() {
+    printf 'tmux-project: %s\n' "$*" >&2
+    exit 1
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+select_project_dir() {
+    local preview
+    local selected_dir
+
+    if command -v eza >/dev/null 2>&1; then
+        preview='eza -l --icons --color=always {}'
+    else
+        preview='ls -la {}'
+    fi
+
+    selected_dir="$(ghq list -p | fzf --prompt='project> ' --preview="$preview")" || return 1
+    [[ -n "$selected_dir" ]] || return 1
+    [[ -d "$selected_dir" ]] || die "selected path is not a directory: $selected_dir"
+
+    printf '%s\n' "$selected_dir"
+}
+
+session_name_for_path() {
+    local project_dir="$1"
+    local name
+
+    name="$(basename -- "$project_dir")"
+    name="$(printf '%s' "$name" | tr -cs '[:alnum:]_.-' '_' | sed 's/^_*//; s/_*$//')"
+    [[ -n "$name" ]] || die "could not derive session name from: $project_dir"
+
+    printf '%s\n' "$name"
+}
+
+session_id_for_name() {
+    local session_name="$1"
+
+    { tmux list-sessions -F '#{session_name}	#{session_id}' 2>/dev/null || true; } |
+        awk -F '\t' -v name="$session_name" '$1 == name { print $2; exit }'
+}
+
+open_session() {
+    local session_id="$1"
+
+    if [[ -n "${TMUX:-}" ]]; then
+        tmux switch-client -t "$session_id"
+    else
+        tmux attach-session -t "$session_id"
+    fi
+}
+
+main() {
+    local project_dir
+    local session_name
+    local session_id
+
+    case "${1:-}" in
+        -h|--help|help)
+            usage
+            return 0
+            ;;
+    esac
+
+    require_cmd ghq
+    require_cmd fzf
+    require_cmd tmux
+
+    project_dir="$(select_project_dir)" || return 0
+    session_name="$(session_name_for_path "$project_dir")"
+    session_id="$(session_id_for_name "$session_name")"
+
+    if [[ -z "$session_id" ]]; then
+        session_id="$(tmux new-session -d -P -F '#{session_id}' -s "$session_name" -n main -c "$project_dir")"
+        [[ -n "$session_id" ]] || session_id="$session_name"
+    fi
+
+    open_session "$session_id"
+}
+
+main "$@"

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -41,7 +41,7 @@ bind g run-shell -b '~/.local/bin/tmux-open popup-lazygit "#{pane_id}"'
 bind G run-shell -b '~/.local/bin/tmux-open split-v-lazygit "#{pane_id}"'
 
 # Open project sessions from a repository picker.
-bind P display-popup -xC -yC -w 85% -h 85% -E '~/.local/bin/tmux-project'
+bind P display-popup -xC -yC -w 85% -h 85% -T ' project ' -E '~/.local/bin/tmux-project'
 
 # Moving windows
 bind -r n next-window
@@ -49,9 +49,6 @@ bind -r p previous-window
 
 # Use vi key bindings in copy mode
 setw -g mode-keys vi
-
-# Style tmux chooser modes such as the session list (`prefix + s`)
-setw -g mode-style 'bg=#89b4fa,fg=#1e1e2e,bold'
 
 # Start selection with 'v'
 bind -T copy-mode-vi v send -X begin-selection
@@ -62,7 +59,14 @@ bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'
 # Enter copy mode with mouse scrolling
 set -g mouse on
 
-# Status bar settings (Catppuccin Mocha)
+# Catppuccin Mocha styling
+setw -g mode-style 'bg=#89b4fa,fg=#1e1e2e,bold'
+
+set -g message-style 'bg=#313244,fg=#cdd6f4'
+set -g message-command-style 'bg=#313244,fg=#cdd6f4'
+set -g popup-style 'bg=#1e1e2e,fg=#cdd6f4'
+set -g popup-border-style 'bg=#1e1e2e,fg=#89b4fa'
+
 set -g status-position bottom
 set -g status-bg '#1e1e2e'
 set -g status-fg '#cdd6f4'
@@ -72,19 +76,17 @@ set -g status-right '#{?window_zoomed_flag,#[fg=#89b4fa]#[bold] Z,}'
 set -g status-right-length 50
 set -g status-left-length 24
 
-# Window status display settings
 setw -g window-status-separator '  '
 setw -g window-status-current-style bg='#1e1e2e',fg='#cdd6f4',bold
-setw -g window-status-current-format '#[fg=#89b4fa,bold]#I #{=/28/...:window_name}'
+setw -g window-status-current-format '#[fg=#89b4fa,bold]#I #[fg=#cdd6f4,bold]#{=/28/...:window_name}'
 
 setw -g window-status-style fg='#6c7086',bg='#1e1e2e'
-setw -g window-status-format '#I #{=/20/...:window_name}'
+setw -g window-status-format '#[fg=#6c7086]#I #[fg=#7f849c]#{=/20/...:window_name}'
 
-# Pane border color settings
 set -g pane-border-style bg='#1e1e2e',fg='#313244'
 set -g pane-active-border-style bg='#1e1e2e',fg='#585b70'
 set -g pane-border-status top
-set -g pane-border-format '#{?pane_active,#[bold]#[fg=#89b4fa],#[fg=#6c7086]} #{pane_index} #{=/24/...:#{?@pane_label,#{@pane_label},#{b:pane_current_path}}} '
+set -g pane-border-format '#{?pane_active,#[bold]#[fg=#89b4fa] #{pane_index} #[fg=#cdd6f4]#{=/24/...:#{?@pane_label,#{@pane_label},#{b:pane_current_path}}} ,#[fg=#6c7086] #{pane_index} #{=/24/...:#{?@pane_label,#{@pane_label},#{b:pane_current_path}}} }'
 
 # Eliminate ESC key delay
 set -sg escape-time 0

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -6,10 +6,18 @@ unbind C-b
 set-option -g prefix C-a
 bind-key C-a send-prefix
 
+# Prefer explicit custom bindings for creating windows and sessions.
+unbind-key c
+unbind-key C-c
+
 # Automatic renumbering of pane and window numbers
 set-option -g renumber-windows on
 
-# Pane/window creation from the active pane's Claude-aware current directory.
+# Keep window names stable; rename them explicitly with prefix + ,.
+set-option -g allow-rename off
+set-option -g automatic-rename off
+
+# Pane creation from the active pane's Claude-aware current directory.
 bind | run-shell -b '~/.local/bin/tmux-open split-h "#{pane_id}"'
 bind - run-shell -b '~/.local/bin/tmux-open split-v "#{pane_id}"'
 
@@ -19,11 +27,21 @@ bind -r J resize-pane -D 5
 bind -r H resize-pane -L 5
 bind -r L resize-pane -R 5
 
+# Create named windows and sessions.
+bind t command-prompt -p "window name:" "new-window -n '%%'"
+bind T command-prompt -p "session name:" "new-session -s '%%'"
+bind r command-prompt -I "#{window_name}" -p "window name:" "rename-window '%%'"
+bind R command-prompt -I "#{session_name}" -p "session name:" "rename-session '%%'"
+bind e command-prompt -I "#{@pane_label}" -p "pane label:" "set-option -p @pane_label '%%'"
+bind E set-option -pu @pane_label
+
 # Open shells and lazygit from the active pane's Claude-aware current directory.
-bind t run-shell -b '~/.local/bin/tmux-open new-window "#{pane_id}"'
 bind u run-shell -b '~/.local/bin/tmux-open popup "#{pane_id}"'
 bind g run-shell -b '~/.local/bin/tmux-open popup-lazygit "#{pane_id}"'
 bind G run-shell -b '~/.local/bin/tmux-open split-v-lazygit "#{pane_id}"'
+
+# Open project sessions from a repository picker.
+bind P display-popup -xC -yC -w 85% -h 85% -E '~/.local/bin/tmux-project'
 
 # Moving windows
 bind -r n next-window

--- a/packages/zsh/.config/zsh/.functions.zsh
+++ b/packages/zsh/.config/zsh/.functions.zsh
@@ -77,15 +77,3 @@ function zoxide_interactive() {
 }
 zle -N zoxide_interactive
 bindkey "^z" zoxide_interactive
-
-# Navigate to ghq repository (Ctrl+@)
-function cdrepo() {
-  local selected_dir=$(ghq list -p | fzf -q "$LBUFFER" --preview='eza -l --icons --color=always {}')
-  if [ -n "$selected_dir" ]; then
-    BUFFER="cd ${selected_dir}"
-    zle accept-line
-  fi
-  zle clear-screen
-}
-zle -N cdrepo
-bindkey '^@' cdrepo

--- a/packages/zsh/.config/zsh/.options.zsh
+++ b/packages/zsh/.config/zsh/.options.zsh
@@ -1,6 +1,7 @@
 # Shell basics
 bindkey -v
-setopt IGNOREEOF correct no_flow_control
+setopt correct no_flow_control
+bindkey -M viins "^D" delete-char-or-list
 autoload -Uz colors && colors
 
 # Completion

--- a/packages/zsh/.config/zsh/.plugins.zsh
+++ b/packages/zsh/.config/zsh/.plugins.zsh
@@ -1,6 +1,6 @@
 # Auto-start tmux (skip in AI agent / VS Code terminals)
 if [ -z "$TMUX" ] && [ -z "$CLAUDE_CODE" ] && [ -z "$CODEX_SHELL" ] && [ "$TERM_PROGRAM" != "vscode" ] && command -v tmux >/dev/null 2>&1; then
-  tmux attach-session -t main || tmux new-session -s main
+  tmux attach-session -t home || tmux new-session -s home -n main
 fi
 
 # Tool initialization

--- a/tests/tmux-project.sh
+++ b/tests/tmux-project.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+# shellcheck source=/dev/null
+source "${REPO_ROOT}/scripts/lib/ui.sh"
+
+TMUX_PROJECT="${REPO_ROOT}/packages/bin/.local/bin/tmux-project"
+
+fail() {
+    warn "$*"
+    exit 1
+}
+
+write_ghq_wrapper() {
+    local wrapper_path="$1"
+
+    cat >"$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "list" && "${2:-}" == "-p" ]]; then
+    printf '%b' "${TMUX_PROJECT_TEST_GHQ_LIST:-}"
+    exit 0
+fi
+
+printf 'unexpected ghq command: %s\n' "$*" >&2
+exit 1
+EOF
+    chmod +x "$wrapper_path"
+}
+
+write_fzf_wrapper() {
+    local wrapper_path="$1"
+    local fzf_log="$2"
+
+    cat >"$wrapper_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'fzf' >>"${fzf_log}"
+for arg in "\$@"; do
+    printf ' %s' "\$arg" >>"${fzf_log}"
+done
+printf '\n' >>"${fzf_log}"
+
+exit_code="\${TMUX_PROJECT_TEST_FZF_EXIT:-0}"
+if [[ "\$exit_code" != "0" ]]; then
+    exit "\$exit_code"
+fi
+
+printf '%s\n' "\${TMUX_PROJECT_TEST_FZF_SELECTION:-}"
+EOF
+    chmod +x "$wrapper_path"
+}
+
+write_tmux_wrapper() {
+    local wrapper_path="$1"
+    local tmux_log="$2"
+
+    cat >"$wrapper_path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+cmd="\${1:-}"
+shift || true
+printf '%s' "\$cmd" >>"${tmux_log}"
+for arg in "\$@"; do
+    printf ' %s' "\$arg" >>"${tmux_log}"
+done
+printf '\n' >>"${tmux_log}"
+
+case "\$cmd" in
+    list-sessions)
+        if [[ "\${TMUX_PROJECT_TEST_LIST_FAIL:-0}" == "1" ]]; then
+            exit 1
+        fi
+        printf '%b' "\${TMUX_PROJECT_TEST_SESSIONS:-}"
+        ;;
+    new-session)
+        printf '%s\n' "\${TMUX_PROJECT_TEST_NEW_SESSION_ID:-new-session-id}"
+        ;;
+    switch-client|attach-session)
+        ;;
+    *)
+        printf 'unexpected tmux command: %s\n' "\$cmd" >&2
+        exit 1
+        ;;
+esac
+EOF
+    chmod +x "$wrapper_path"
+}
+
+setup_wrappers() {
+    local wrapper_dir="$1"
+    local tmux_log="$2"
+    local fzf_log="$3"
+
+    write_ghq_wrapper "${wrapper_dir}/ghq"
+    write_fzf_wrapper "${wrapper_dir}/fzf" "$fzf_log"
+    write_tmux_wrapper "${wrapper_dir}/tmux" "$tmux_log"
+}
+
+run_tmux_project() {
+    local wrapper_dir="$1"
+    shift
+
+    PATH="${wrapper_dir}:$PATH" "$TMUX_PROJECT" "$@"
+}
+
+test_creates_and_switches_inside_tmux() {
+    local wrapper_dir
+    local tmux_log
+    local fzf_log
+    local tmpdir
+    local project_dir
+
+    wrapper_dir="$(mktemp -d /tmp/tmux-project-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-project-log.XXXXXX)"
+    fzf_log="$(mktemp /tmp/tmux-project-fzf-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-project-create.XXXXXX)"
+    project_dir="${tmpdir}/my-app"
+    mkdir -p "$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log" "$fzf_log"
+
+    TMUX="/tmp/tmux-test" \
+        TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
+        TMUX_PROJECT_TEST_FZF_SELECTION="$project_dir" \
+        TMUX_PROJECT_TEST_NEW_SESSION_ID="\$42" \
+        run_tmux_project "$wrapper_dir"
+
+    grep -F "new-session -d -P -F #{session_id} -s my-app -n main -c ${project_dir}" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to create a project session"
+    grep -F "switch-client -t \$42" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to switch to the new session inside tmux"
+    grep -F "fzf --prompt=project>  --preview=" "$fzf_log" >/dev/null ||
+        fail "expected tmux-project to open fzf with a project prompt"
+
+    rm -rf "$wrapper_dir" "$tmux_log" "$fzf_log" "$tmpdir"
+}
+
+test_switches_existing_session_inside_tmux() {
+    local wrapper_dir
+    local tmux_log
+    local fzf_log
+    local tmpdir
+    local project_dir
+
+    wrapper_dir="$(mktemp -d /tmp/tmux-project-existing-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-project-existing-log.XXXXXX)"
+    fzf_log="$(mktemp /tmp/tmux-project-existing-fzf-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-project-existing.XXXXXX)"
+    project_dir="${tmpdir}/my-app"
+    mkdir -p "$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log" "$fzf_log"
+
+    TMUX="/tmp/tmux-test" \
+        TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
+        TMUX_PROJECT_TEST_FZF_SELECTION="$project_dir" \
+        TMUX_PROJECT_TEST_SESSIONS="my-app\t\$7\n" \
+        run_tmux_project "$wrapper_dir"
+
+    if grep -F "new-session" "$tmux_log" >/dev/null; then
+        fail "expected tmux-project not to create an existing session"
+    fi
+    grep -F "switch-client -t \$7" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to switch to the existing session"
+
+    rm -rf "$wrapper_dir" "$tmux_log" "$fzf_log" "$tmpdir"
+}
+
+test_creates_and_attaches_outside_tmux() {
+    local wrapper_dir
+    local tmux_log
+    local fzf_log
+    local tmpdir
+    local project_dir
+
+    wrapper_dir="$(mktemp -d /tmp/tmux-project-attach-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-project-attach-log.XXXXXX)"
+    fzf_log="$(mktemp /tmp/tmux-project-attach-fzf-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-project-attach.XXXXXX)"
+    project_dir="${tmpdir}/my app:api"
+    mkdir -p "$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log" "$fzf_log"
+
+    TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
+        TMUX_PROJECT_TEST_FZF_SELECTION="$project_dir" \
+        TMUX_PROJECT_TEST_LIST_FAIL=1 \
+        TMUX_PROJECT_TEST_NEW_SESSION_ID="\$9" \
+        run_tmux_project "$wrapper_dir"
+
+    grep -F "new-session -d -P -F #{session_id} -s my_app_api -n main -c ${project_dir}" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to sanitize the session name"
+    grep -F "attach-session -t \$9" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to attach outside tmux"
+
+    rm -rf "$wrapper_dir" "$tmux_log" "$fzf_log" "$tmpdir"
+}
+
+test_cancel_does_not_call_tmux() {
+    local wrapper_dir
+    local tmux_log
+    local fzf_log
+    local tmpdir
+    local project_dir
+
+    wrapper_dir="$(mktemp -d /tmp/tmux-project-cancel-wrapper.XXXXXX)"
+    tmux_log="$(mktemp /tmp/tmux-project-cancel-log.XXXXXX)"
+    fzf_log="$(mktemp /tmp/tmux-project-cancel-fzf-log.XXXXXX)"
+    tmpdir="$(mktemp -d /tmp/tmux-project-cancel.XXXXXX)"
+    project_dir="${tmpdir}/my-app"
+    mkdir -p "$project_dir"
+    setup_wrappers "$wrapper_dir" "$tmux_log" "$fzf_log"
+
+    TMUX="/tmp/tmux-test" \
+        TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
+        TMUX_PROJECT_TEST_FZF_EXIT=130 \
+        run_tmux_project "$wrapper_dir"
+
+    if [[ -s "$tmux_log" ]]; then
+        fail "expected tmux-project not to call tmux after picker cancellation"
+    fi
+
+    rm -rf "$wrapper_dir" "$tmux_log" "$fzf_log" "$tmpdir"
+}
+
+main() {
+    step "Running tmux-project tests"
+    test_creates_and_switches_inside_tmux
+    ok "creates and switches to project sessions inside tmux"
+    test_switches_existing_session_inside_tmux
+    ok "switches to existing project sessions"
+    test_creates_and_attaches_outside_tmux
+    ok "creates and attaches to project sessions outside tmux"
+    test_cancel_does_not_call_tmux
+    ok "cancels without calling tmux"
+}
+
+main "$@"

--- a/tests/tmux-project.sh
+++ b/tests/tmux-project.sh
@@ -46,6 +46,7 @@ for arg in "\$@"; do
     printf ' %s' "\$arg" >>"${fzf_log}"
 done
 printf '\n' >>"${fzf_log}"
+cat >/dev/null
 
 exit_code="\${TMUX_PROJECT_TEST_FZF_EXIT:-0}"
 if [[ "\$exit_code" != "0" ]]; then
@@ -187,7 +188,8 @@ test_creates_and_attaches_outside_tmux() {
     mkdir -p "$project_dir"
     setup_wrappers "$wrapper_dir" "$tmux_log" "$fzf_log"
 
-    TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
+    TMUX= \
+        TMUX_PROJECT_TEST_GHQ_LIST="${project_dir}\n" \
         TMUX_PROJECT_TEST_FZF_SELECTION="$project_dir" \
         TMUX_PROJECT_TEST_LIST_FAIL=1 \
         TMUX_PROJECT_TEST_NEW_SESSION_ID="\$9" \


### PR DESCRIPTION
## Summary
- Add `tmux-project`, a `ghq` + `fzf` picker (`prefix + P`) that switches to an existing project session or creates one with a `main` window
- Add explicit bindings for creating/renaming named windows and sessions (`prefix + t`/`T`/`r`/`R`) and editing pane labels (`prefix + e`/`E`); keep window names stable (`allow-rename`/`automatic-rename` off)
- Auto-start a `home` tmux session with a `main` window in interactive zsh (still skipped in Claude/Codex/VS Code terminals)
- Polish Catppuccin Mocha styling (message/popup styles, window status, pane border format) and add a titled popup for the project picker
- Replace the `Ctrl+@` `cdrepo` zsh function with the tmux project picker; swap `IGNOREEOF` for `^D` list-completion in viins
- Add `tests/tmux-project.sh` regression tests and update `README.md` / `KEYBINDINGS.md`

## Test plan
- [x] `bash tests/tmux-project.sh`
- [x] `bash tests/tmux-open.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)