### PR TITLE
Improve Claude and tmux project handling

### DIFF
--- a/packages/claude/.claude/_settings-source/shared.json
+++ b/packages/claude/.claude/_settings-source/shared.json
@@ -25,6 +25,11 @@
       "Bash(chmod 777 /*)",
       "Bash(git push --force:*)",
       "Bash(git push -f:*)",
+      "Bash(gh repo delete:*)",
+      "Bash(gh release delete:*)",
+      "Bash(gh api -X DELETE:*)",
+      "Bash(gh api --method DELETE:*)",
+      "Bash(gh auth logout:*)",
       "Bash(rm -rf /)",
       "Bash(rm -rf /*)",
       "Bash(rm -rf ~)",
@@ -71,6 +76,16 @@
           }
         ]
       }
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": false,
+    "allowUnsandboxedCommands": false,
+    "excludedCommands": [
+      "gh *",
+      "swift *",
+      "xcodebuild *"
     ]
   },
   "statusLine": {

--- a/packages/tmux/.local/libexec/tmux/lib/pane-cwd.sh
+++ b/packages/tmux/.local/libexec/tmux/lib/pane-cwd.sh
@@ -25,7 +25,7 @@ tmux_path_related() {
     [[ "$left" == "$right" || "$left" == "$right"/* || "$right" == "$left"/* ]]
 }
 
-tmux_pane_has_claude_agents() {
+tmux_pane_has_claude() {
     local pane_id="$1"
     local pane_tty
     local tty_name
@@ -35,7 +35,7 @@ tmux_pane_has_claude_agents() {
 
     tty_name="${pane_tty#/dev/}"
     ps -o command= -t "$tty_name" 2>/dev/null |
-        grep -E '(^|/)claude([[:space:]].*)?[[:space:]]agents([[:space:]]|$)' >/dev/null 2>&1 ||
+        grep -E '(^|/)claude([[:space:]]|$)' >/dev/null 2>&1 ||
         return 1
 }
 
@@ -93,7 +93,7 @@ tmux_resolved_cwd() {
     local claude_cwd
 
     pane_current_path="$(tmux_pane_format "$pane_id" "#{pane_current_path}")"
-    if tmux_pane_has_claude_agents "$pane_id"; then
+    if tmux_pane_has_claude "$pane_id"; then
         if claude_cwd="$(tmux_latest_claude_cwd "$pane_current_path")" && [[ -n "$claude_cwd" && -d "$claude_cwd" ]]; then
             printf '%s\n' "$claude_cwd"
             return 0

--- a/packages/tmux/.local/libexec/tmux/project
+++ b/packages/tmux/.local/libexec/tmux/project
@@ -37,6 +37,12 @@ project_label_for_path() {
     fi
 }
 
+project_repository_for_path() {
+    local project_dir="$1"
+
+    basename -- "$project_dir"
+}
+
 project_records() {
     local project_dir
     local label
@@ -92,6 +98,19 @@ session_id_for_name() {
         awk -F '\t' -v name="$session_name" '$1 == name { print $2; exit }'
 }
 
+set_project_labels() {
+    local session_id="$1"
+    local project_dir="$2"
+    local project_label
+    local project_full_label
+
+    project_label="$(project_repository_for_path "$project_dir")"
+    project_full_label="$(project_label_for_path "$project_dir")"
+
+    tmux set-option -q -t "$session_id" @project_label "$project_label"
+    tmux set-option -q -t "$session_id" @project_full_label "$project_full_label"
+}
+
 open_session() {
     local session_id="$1"
 
@@ -126,6 +145,7 @@ main() {
         session_id="$(tmux new-session -d -P -F '#{session_id}' -s "$session_name" -n main -c "$project_dir")"
         [[ -n "$session_id" ]] || session_id="$session_name"
     fi
+    set_project_labels "$session_id" "$project_dir"
 
     open_session "$session_id"
 }

--- a/packages/tmux/.tmux.conf
+++ b/packages/tmux/.tmux.conf
@@ -30,7 +30,7 @@ set-option -s command-alias[108] 'my-shell-popup=run-shell -b "~/.local/libexec/
 set-option -s command-alias[109] 'my-lazygit-popup=run-shell -b "~/.local/libexec/tmux/open popup-lazygit #{pane_id}"'
 set-option -s command-alias[110] 'my-lazygit-bottom-pane=run-shell -b "~/.local/libexec/tmux/run-in-pane --select below #{pane_id} lazygit"'
 set-option -s command-alias[111] 'my-open-project=display-popup -xC -yC -w 85% -h 85% -T " project " -E "~/.local/libexec/tmux/project"'
-set-option -s command-alias[112] 'my-switch-session=choose-tree -Zs -O activity -F "#{?session_attached,#[fg=#a6e3a1]● ,  }#[default]#{session_name} #[fg=#6c7086](#{session_windows} windows)#[default]"'
+set-option -s command-alias[112] 'my-switch-session=choose-tree -Zs -O activity -F "#{?session_attached,#[fg=#a6e3a1]● ,  }#[default]#{?@project_full_label,#{@project_full_label},#{session_name}} #[fg=#6c7086](#{session_windows} windows)#[default]"'
 set-option -s command-alias[113] 'my-file-refs=run-shell -b "~/.local/libexec/tmux/file-refs #{pane_id}"'
 
 # Pane creation from the active pane's Claude-aware current directory.
@@ -109,10 +109,10 @@ set -g status-position bottom
 set -g status-bg '#1e1e2e'
 set -g status-fg '#cdd6f4'
 set -g status-style 'bg=#1e1e2e,fg=#bac2de'
-set -g status-left '#[fg=#cdd6f4,bg=#313244,bold] #{=/18/...:session_name} #[bg=#1e1e2e,fg=#1e1e2e]  '
+set -g status-left '#[fg=#cdd6f4,bg=#313244,bold] #{=-28/...:#{?@project_label,#{@project_label},#{session_name}}} #[bg=#1e1e2e,fg=#1e1e2e]  '
 set -g status-right '#{?window_zoomed_flag,#[fg=#89b4fa]#[bold] Z,}'
 set -g status-right-length 50
-set -g status-left-length 24
+set -g status-left-length 34
 
 setw -g window-status-separator '  '
 setw -g window-status-current-style bg='#1e1e2e',fg='#cdd6f4',bold

--- a/tests/tmux-open.sh
+++ b/tests/tmux-open.sh
@@ -144,7 +144,7 @@ test_uses_latest_matching_claude_cwd_for_popup() {
     write_claude_state "$tmpdir" other "$other_cwd" "$other_project_dir" 202401010002.00
 
     TMPDIR="$tmpdir" \
-        TMUX_TEST_PS_COMMANDS="claude agents" \
+        TMUX_TEST_PS_COMMANDS="claude --dangerously-skip-permissions" \
         TMUX_TEST_PANE_CURRENT_PATH="$fallback_cwd" \
         run_tmux_open "$wrapper_dir" popup-lazygit "%1"
 

--- a/tests/tmux-project.sh
+++ b/tests/tmux-project.sh
@@ -85,7 +85,7 @@ case "\$cmd" in
     new-session)
         printf '%s\n' "\${TMUX_PROJECT_TEST_NEW_SESSION_ID:-new-session-id}"
         ;;
-    switch-client|attach-session)
+    set-option|switch-client|attach-session)
         ;;
     *)
         printf 'unexpected tmux command: %s\n' "\$cmd" >&2
@@ -139,6 +139,10 @@ test_creates_and_switches_inside_tmux() {
 
     grep -F "new-session -d -P -F #{session_id} -s acme_my-app -n main -c ${project_dir}" "$tmux_log" >/dev/null ||
         fail "expected tmux-project to create a project session"
+    grep -F "set-option -q -t \$42 @project_label my-app" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to set a short project label"
+    grep -F "set-option -q -t \$42 @project_full_label acme/my-app" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to set a full project label"
     grep -F "switch-client -t \$42" "$tmux_log" >/dev/null ||
         fail "expected tmux-project to switch to the new session inside tmux"
     grep -F -- $'--delimiter=\t' "$fzf_log" >/dev/null ||
@@ -181,6 +185,10 @@ test_switches_existing_session_inside_tmux() {
     fi
     grep -F "switch-client -t \$7" "$tmux_log" >/dev/null ||
         fail "expected tmux-project to switch to the existing session"
+    grep -F "set-option -q -t \$7 @project_label my-app" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to refresh the short project label"
+    grep -F "set-option -q -t \$7 @project_full_label acme/my-app" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to refresh the full project label"
 
     rm -rf "$wrapper_dir" "$tmux_log" "$fzf_log" "$fzf_input" "$tmpdir"
 }
@@ -211,6 +219,10 @@ test_creates_and_attaches_outside_tmux() {
 
     grep -F "new-session -d -P -F #{session_id} -s acme_my_app_api -n main -c ${project_dir}" "$tmux_log" >/dev/null ||
         fail "expected tmux-project to sanitize the session name"
+    grep -F "set-option -q -t \$9 @project_label my app:api" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to keep the repository label readable"
+    grep -F "set-option -q -t \$9 @project_full_label acme/my app:api" "$tmux_log" >/dev/null ||
+        fail "expected tmux-project to keep the full label readable"
     grep -F "attach-session -t \$9" "$tmux_log" >/dev/null ||
         fail "expected tmux-project to attach outside tmux"
 

--- a/tests/tmux-run-in-pane.sh
+++ b/tests/tmux-run-in-pane.sh
@@ -145,7 +145,7 @@ test_below_runs_command_from_claude_cwd() {
     write_claude_state "$tmpdir" agent "$claude_cwd" "$project_dir" 202401010000.00
 
     TMPDIR="$tmpdir" \
-        TMUX_TEST_PS_COMMANDS="claude agents" \
+        TMUX_TEST_PS_COMMANDS="claude --dangerously-skip-permissions" \
         TMUX_TEST_PANE_CURRENT_PATH="$project_dir" \
         TMUX_TEST_LIST_PANES=$'%1\t0\t0\t100\t20\n%2\t0\t21\t100\t20' \
         TMUX_TEST_PANE_CURRENT_COMMAND="zsh" \


### PR DESCRIPTION
## Summary

- Relax tmux Claude pane detection so Claude CLI invocations without the agents subcommand still use recorded cwd state
- Add Claude sandbox settings and deny destructive GitHub CLI operations
- Store project display labels so tmux status shows repo names and the session chooser shows org/repo labels

## Tests

- bash tests/tmux-open.sh
- bash tests/tmux-run-in-pane.sh
- bash tests/generate-claude-settings.sh
- bash tests/tmux-project.sh